### PR TITLE
Fix Windows version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-upload": "^2.3.2",
     "fflate": "^0.8.2",
     "lucide-vue-next": "^0.562.0",
@@ -20,7 +21,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/cli": "^2.1.0",
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.1.1
+        version: 2.9.0
       '@tauri-apps/plugin-upload':
         specifier: ^2.3.2
         version: 2.3.2
@@ -24,9 +27,6 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
-      '@tauri-apps/api':
-        specifier: ^2.1.1
-        version: 2.9.0
       '@tauri-apps/cli':
         specifier: ^2.1.0
         version: 2.9.4
@@ -311,56 +311,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -416,30 +427,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.9.4':
     resolution: {integrity: sha512-vg7yNn7ICTi6hRrcA/6ff2UpZQP7un3xe3SEld5QM0prgridbKAiXGaCKr3BnUBx/rGXegQlD/wiLcWdiiraSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.9.4':
     resolution: {integrity: sha512-l8L+3VxNk6yv5T/Z/gv5ysngmIpsai40B9p6NQQyqYqxImqYX37pqREoEBl1YwG7szGnDibpWhidPrWKR59OJA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.9.4':
     resolution: {integrity: sha512-PepPhCXc/xVvE3foykNho46OmCyx47E/aG676vKTVp+mqin5d+IBqDL6wDKiGNT5OTTxKEyNlCQ81Xs2BQhhqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.9.4':
     resolution: {integrity: sha512-zcd1QVffh5tZs1u1SCKUV/V7RRynebgYUNWHuV0FsIF1MjnULUChEXhAhug7usCDq4GZReMJOoXa6rukEozWIw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.9.4':
     resolution: {integrity: sha512-/7ZhnP6PY04bEob23q8MH/EoDISdmR1wuNm0k9d5HV7TDMd2GGCDa8dPXA4vJuglJKXIfXqxFmZ4L+J+MO42+w==}

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,136 +1,147 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
-  "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
-  "permissions": [
-    "core:default",
-    "mcp-bridge:default",
-    "dialog:default",
-    "dialog:allow-open",
-    "fs:default",
-    "fs:allow-read-text-file",
-    "fs:allow-write-text-file",
-    "fs:allow-read-file",
-    "fs:allow-exists",
-    "fs:allow-read-dir",
-    "fs:allow-mkdir",
-    "fs:allow-write-file",
-    "fs:allow-remove",
-    "fs:allow-stat",
-    "fs:allow-rename",
+  "capabilities": [
     {
-      "identifier": "fs:scope",
-      "allow": [
-        "$RESOURCE/**",
-        "$APPDATA/**",
-        "$HOME/Library/Application Support/gzdoom",
-        "$HOME/Library/Application Support/gzdoom/**",
-        "$HOME/Library/Application Support/rusted-doom-launcher",
-        "$HOME/Library/Application Support/rusted-doom-launcher/**",
-        "/Applications/UZDoom.app/**",
-        "/Applications/GZDoom.app/**",
-        "/opt/homebrew/bin/uzdoom",
-        "/opt/homebrew/bin/gzdoom",
-        "/usr/local/bin/uzdoom",
-        "/usr/local/bin/gzdoom",
-        "$HOME/Applications/UZDoom.app/**",
-        "$HOME/Applications/GZDoom.app/**"
-      ]
-    },
-    "http:default",
-    "upload:default",
-    {
-      "identifier": "upload:allow-download",
-      "allow": [
-        { "path": "$HOME/Library/Application Support/gzdoom/**" },
-        { "path": "$HOME/Library/Application Support/rusted-doom-launcher/**" }
-      ]
-    },
-    {
-      "identifier": "http:allow-fetch",
-      "allow": [
-        { "url": "https://*" }
-      ]
-    },
-    "shell:default",
-    {
-      "identifier": "shell:allow-spawn",
-      "allow": [
+      "identifier": "mod-manager-files",
+      "description": "Permissions for mod manager files and downloads",
+      "windows": ["main"],
+      "permissions": [
+        "core:default",
+        "mcp-bridge:default",
+        "dialog:default",
+        "fs:default",
+        "fs:allow-app-write-recursive",
+        "fs:allow-app-meta-recursive",
+        "http:default",
+        "upload:default",
         {
-          "name": "uzdoom",
-          "cmd": "/Applications/UZDoom.app/Contents/MacOS/uzdoom",
-          "args": true
+          "identifier": "upload:allow-download",
+          "allow": [
+            { "path": "$APPDATA/com.doomwads.launcher/**" }
+          ]
         },
         {
-          "name": "gzdoom",
-          "cmd": "/Applications/GZDoom.app/Contents/MacOS/gzdoom",
-          "args": true
-        },
-        {
-          "name": "uzdoom-homebrew-arm",
-          "cmd": "/opt/homebrew/bin/uzdoom",
-          "args": true
-        },
-        {
-          "name": "gzdoom-homebrew-arm",
-          "cmd": "/opt/homebrew/bin/gzdoom",
-          "args": true
-        },
-        {
-          "name": "uzdoom-homebrew-intel",
-          "cmd": "/usr/local/bin/uzdoom",
-          "args": true
-        },
-        {
-          "name": "gzdoom-homebrew-intel",
-          "cmd": "/usr/local/bin/gzdoom",
-          "args": true
-        },
-        {
-          "name": "uzdoom-user-apps",
-          "cmd": "$HOME/Applications/UZDoom.app/Contents/MacOS/uzdoom",
-          "args": true
-        },
-        {
-          "name": "gzdoom-user-apps",
-          "cmd": "$HOME/Applications/GZDoom.app/Contents/MacOS/gzdoom",
-          "args": true
-        },
-        {
-          "name": "innoextract",
-          "cmd": "innoextract",
-          "args": true
-        },
-        {
-          "name": "innoextract-homebrew-arm",
-          "cmd": "/opt/homebrew/bin/innoextract",
-          "args": true
-        },
-        {
-          "name": "innoextract-homebrew-intel",
-          "cmd": "/usr/local/bin/innoextract",
-          "args": true
+          "identifier": "http:allow-fetch",
+          "allow": [
+            { "url": "https://*" }
+          ]
         }
       ]
     },
     {
-      "identifier": "shell:allow-execute",
-      "allow": [
+      "identifier": "innoextract",
+      "description": "Permissions for innoextract",
+      "windows": ["main"],
+      "permissions": [
+        "core:default",
+        "shell:default",
         {
-          "name": "innoextract",
-          "cmd": "innoextract",
-          "args": true
+          "identifier": "shell:allow-spawn",
+          "allow": [
+            {
+              "name": "innoextract",
+              "cmd": "innoextract",
+              "args": true
+            },
+            {
+              "name": "innoextract-homebrew-arm",
+              "cmd": "/opt/homebrew/bin/innoextract",
+              "args": true
+            },
+            {
+              "name": "innoextract-homebrew-intel",
+              "cmd": "/usr/local/bin/innoextract",
+              "args": true
+            }
+          ]
         },
         {
-          "name": "innoextract-homebrew-arm",
-          "cmd": "/opt/homebrew/bin/innoextract",
-          "args": true
-        },
+          "identifier": "shell:allow-execute",
+          "allow": [
+            {
+              "name": "innoextract",
+              "cmd": "innoextract",
+              "args": true
+            },
+            {
+              "name": "innoextract-homebrew-arm",
+              "cmd": "/opt/homebrew/bin/innoextract",
+              "args": true
+            },
+            {
+              "name": "innoextract-homebrew-intel",
+              "cmd": "/usr/local/bin/innoextract",
+              "args": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "identifier": "doom-engines",
+      "description": "Permissions for GZDoom/UZDoom executables",
+      "windows": ["main"],
+      "permissions": [
+        "core:default",
+        "fs:allow-exists",
         {
-          "name": "innoextract-homebrew-intel",
-          "cmd": "/usr/local/bin/innoextract",
-          "args": true
+          "identifier": "fs:scope",
+          "allow": [
+            "/Applications/UZDoom.app/**",
+            "/Applications/GZDoom.app/**",
+            "/opt/homebrew/bin/uzdoom",
+            "/opt/homebrew/bin/gzdoom",
+            "/usr/local/bin/uzdoom",
+            "/usr/local/bin/gzdoom",
+            "$HOME/Applications/UZDoom.app/**",
+            "$HOME/Applications/GZDoom.app/**"
+          ]
+        },
+        "shell:default",
+        {
+          "identifier": "shell:allow-spawn",
+          "allow": [
+            {
+              "name": "uzdoom",
+              "cmd": "/Applications/UZDoom.app/Contents/MacOS/uzdoom",
+              "args": true
+            },
+            {
+              "name": "gzdoom",
+              "cmd": "/Applications/GZDoom.app/Contents/MacOS/gzdoom",
+              "args": true
+            },
+            {
+              "name": "uzdoom-homebrew-arm",
+              "cmd": "/opt/homebrew/bin/uzdoom",
+              "args": true
+            },
+            {
+              "name": "gzdoom-homebrew-arm",
+              "cmd": "/opt/homebrew/bin/gzdoom",
+              "args": true
+            },
+            {
+              "name": "uzdoom-homebrew-intel",
+              "cmd": "/usr/local/bin/uzdoom",
+              "args": true
+            },
+            {
+              "name": "gzdoom-homebrew-intel",
+              "cmd": "/usr/local/bin/gzdoom",
+              "args": true
+            },
+            {
+              "name": "uzdoom-user-apps",
+              "cmd": "$HOME/Applications/UZDoom.app/Contents/MacOS/uzdoom",
+              "args": true
+            },
+            {
+              "name": "gzdoom-user-apps",
+              "cmd": "$HOME/Applications/GZDoom.app/Contents/MacOS/gzdoom",
+              "args": true
+            }
+          ]
         }
       ]
     }

--- a/src-tauri/src/launcher_downloads.rs
+++ b/src-tauri/src/launcher_downloads.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LauncherDownloads {
+	pub version: u8,
+	pub downloads: HashMap<String, DownloadInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DownloadInfo {
+	pub filename: String,
+	#[serde(rename = "downloadedAt")]
+	pub downloaded_at: String,
+	pub size: u64,
+}
+
+impl LauncherDownloads {
+	pub fn empty() -> Self {
+		Self {
+			version: 1,
+			downloads: HashMap::new(),
+		}
+	}
+}
+
+/// Build the full path to launcher-downloads.json in a library directory.
+pub fn launcher_downloads_path(library_path: impl AsRef<Path>) -> PathBuf {
+	library_path.as_ref().join("launcher-downloads.json")
+}
+
+/// Read launcher-downloads.json from disk.
+pub fn read_launcher_downloads(path: impl AsRef<Path>) -> Result<LauncherDownloads, String> {
+	let path = path.as_ref();
+	let content = fs::read_to_string(path)
+		.map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+	serde_json::from_str::<LauncherDownloads>(&content)
+		.map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
+}
+
+/// Read launcher-downloads.json, returning an empty state if the file is missing.
+pub fn read_launcher_downloads_or_empty(
+	path: impl AsRef<Path>,
+) -> Result<LauncherDownloads, String> {
+	let path = path.as_ref();
+	match fs::read_to_string(path) {
+		Ok(content) => serde_json::from_str::<LauncherDownloads>(&content)
+			.map_err(|e| format!("Failed to parse {}: {}", path.display(), e)),
+		Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(LauncherDownloads::empty()),
+		Err(e) => Err(format!("Failed to read {}: {}", path.display(), e)),
+	}
+}
+
+/// Write launcher-downloads.json to disk, creating parent directories if needed.
+pub fn write_launcher_downloads(
+	path: impl AsRef<Path>,
+	state: &LauncherDownloads,
+) -> Result<(), String> {
+	let path = path.as_ref();
+	if let Some(parent) = path.parent() {
+		fs::create_dir_all(parent)
+			.map_err(|e| format!("Failed to create {}: {}", parent.display(), e))?;
+	}
+	let json = serde_json::to_string_pretty(state)
+		.map_err(|e| format!("Failed to serialize launcher downloads: {}", e))?;
+	fs::write(path, json)
+		.map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,23 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+pub mod launcher_downloads;
 mod wad_parser;
+
+#[tauri::command]
+async fn read_launcher_downloads(library_path: String) -> Result<launcher_downloads::LauncherDownloads, String> {
+    let path = launcher_downloads::launcher_downloads_path(library_path);
+    launcher_downloads::read_launcher_downloads_or_empty(path)
+}
+
+#[tauri::command]
+async fn write_launcher_downloads(
+    library_path: String,
+    state: launcher_downloads::LauncherDownloads,
+) -> Result<(), String> {
+    let path = launcher_downloads::launcher_downloads_path(library_path);
+    launcher_downloads::write_launcher_downloads(path, &state)
+}
 
 // Global state to hold the running GZDoom process output collector
 static GZDOOM_LOG: std::sync::OnceLock<Arc<Mutex<GZDoomSession>>> = std::sync::OnceLock::new();
@@ -206,7 +222,9 @@ pub fn run() {
             get_engine_version,
             is_process_running,
             extract_wad_level_names,
-            extract_and_save_level_names
+            extract_and_save_level_names,
+            read_launcher_downloads,
+            write_launcher_downloads
         ]);
 
     // MCP bridge for Claude Code debugging (dev mode only)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tauri::Manager;
 
 pub mod launcher_downloads;
 mod wad_parser;
@@ -216,6 +217,12 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_upload::init())
+        .setup(|app| {
+            let app_data_dir = app.path().app_data_dir()?;
+            std::fs::create_dir_all(&app_data_dir)
+                .map_err(|e| format!("Failed to create app data dir: {e}"))?;
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             launch_gzdoom,
             get_gzdoom_log,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Rusted Doom Launcher",
   "version": "0.1.6",
-  "identifier": "com.doomwads.launcher",
+  "identifier": "rusted-doom-launcher",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -123,9 +123,18 @@ async function browseAndImportGOG() {
 }
 
 async function browseGZDoom() {
+  const os = getOsForFilters();
+  const macFilter = { name: "Mac Application", extensions: ["app"] };
+  const winFilter = { name: "Windows Executable", extensions: ["exe"] };
+  const anyFilter = { name: "Any", extensions: ["*"] };
+  const filters = os === "mac"
+    ? [macFilter, winFilter, anyFilter]
+    : os === "win"
+      ? [winFilter, macFilter, anyFilter]
+      : [anyFilter, macFilter, winFilter];
   const selected = await open({
     title: "Select Doom Engine (UZDoom or GZDoom)",
-    filters: [{ name: "Application", extensions: ["app"] }],
+    filters,
     directory: false,
     multiple: false,
   });
@@ -169,6 +178,13 @@ function getEngineName(path: string | null): string {
   if (path.toLowerCase().includes("uzdoom")) return "UZDoom";
   if (path.toLowerCase().includes("gzdoom")) return "GZDoom";
   return "Doom engine";
+}
+
+function getOsForFilters(): "mac" | "win" | "linux" {
+  const ua = navigator.userAgent;
+  if (/Mac|iPhone|iPad|iPod/i.test(ua)) return "mac";
+  if (/Win/i.test(ua)) return "win";
+  return "linux";
 }
 
 </script>

--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -1,11 +1,11 @@
 import { ref } from "vue";
-import { exists, mkdir, remove, readTextFile, writeTextFile, readFile, rename, stat } from "@tauri-apps/plugin-fs";
+import { exists, mkdir, remove, readFile, rename, stat } from "@tauri-apps/plugin-fs";
 import { download as tauriDownload } from "@tauri-apps/plugin-upload";
+import { invoke } from "@tauri-apps/api/core";
 import type { WadEntry } from "../lib/schema";
-import { LauncherDownloadsSchema, type LauncherDownloads } from "../lib/schema";
+import { type LauncherDownloads } from "../lib/schema";
 import { useSettings } from "./useSettings";
 import { useLevelNames } from "./useLevelNames";
-import { isNotFoundError } from "../lib/errors";
 
 // Progress info for a download
 export interface DownloadProgress {
@@ -52,22 +52,11 @@ export function useDownload() {
 
   async function loadState() {
     const dir = settings.value.libraryPath;
-    try {
-      const content = await readTextFile(`${dir}/launcher-downloads.json`);
-      const parsed = LauncherDownloadsSchema.safeParse(JSON.parse(content));
-      if (parsed.success) {
-        downloads.value = parsed.data;
-      } else {
-        console.error("launcher-downloads.json schema validation failed:", parsed.error);
-      }
-    } catch (e) {
-      if (!isNotFoundError(e)) throw e;
-      // File doesn't exist yet - that's expected on first run
-    }
+    downloads.value = await invoke<LauncherDownloads>("read_launcher_downloads", { libraryPath: dir });
   }
 
   async function saveState() {
-    await writeTextFile(`${settings.value.libraryPath}/launcher-downloads.json`, JSON.stringify(downloads.value, null, 2));
+    await invoke("write_launcher_downloads", { libraryPath: settings.value.libraryPath, state: downloads.value });
   }
 
   function isDownloaded(slug: string): boolean {

--- a/src/composables/useLevelNames.ts
+++ b/src/composables/useLevelNames.ts
@@ -1,9 +1,10 @@
 import { ref } from "vue";
 import { readFile, readTextFile, writeTextFile, exists, mkdir } from "@tauri-apps/plugin-fs";
+import { invoke } from "@tauri-apps/api/core";
 import { unzipSync, strFromU8 } from "fflate";
 import { extractLevelNames, extractLevelNamesFromData } from "../lib/wadParser";
 import { useSettings } from "./useSettings";
-import { LauncherDownloadsSchema } from "../lib/schema";
+import type { LauncherDownloads } from "../lib/schema";
 import { isNotFoundError } from "../lib/errors";
 
 // Singleton cache: slug -> (mapId -> levelName)
@@ -60,15 +61,10 @@ export function useLevelNames() {
    */
   async function getDownloadInfo(slug: string): Promise<{ filename: string } | null> {
     try {
-      const content = await readTextFile(`${settings.value.libraryPath}/launcher-downloads.json`);
-      const parsed = LauncherDownloadsSchema.safeParse(JSON.parse(content));
-      if (parsed.success && parsed.data.downloads[slug]) {
-        return parsed.data.downloads[slug];
-      }
+      const state = await invoke<LauncherDownloads>("read_launcher_downloads", { libraryPath: settings.value.libraryPath });
+      if (state.downloads[slug]) return state.downloads[slug];
     } catch (e) {
-      if (!isNotFoundError(e)) {
-        console.error(`Error reading launcher-downloads.json for ${slug}:`, e);
-      }
+      console.error(`Error reading launcher-downloads.json for ${slug}:`, e);
     }
     return null;
   }
@@ -202,16 +198,9 @@ export function useLevelNames() {
    */
   async function rescanAllWads(): Promise<number> {
     try {
-      const content = await readTextFile(`${settings.value.libraryPath}/launcher-downloads.json`);
-      const parsed = LauncherDownloadsSchema.safeParse(JSON.parse(content));
-
-      if (!parsed.success) {
-        console.error("Failed to parse launcher-downloads.json");
-        return 0;
-      }
-
+      const state = await invoke<LauncherDownloads>("read_launcher_downloads", { libraryPath: settings.value.libraryPath });
       let count = 0;
-      for (const slug of Object.keys(parsed.data.downloads)) {
+      for (const slug of Object.keys(state.downloads)) {
         // Clear cache to force re-parse
         levelNamesCache.value.delete(slug);
         const levels = await loadLevelNames(slug);

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { homeDir } from "@tauri-apps/api/path";
+import { appConfigDir, appDataDir, homeDir, join } from "@tauri-apps/api/path";
 import { exists, readTextFile, writeTextFile, mkdir, readDir, readFile, writeFile } from "@tauri-apps/plugin-fs";
 import { Command } from "@tauri-apps/plugin-shell";
 import { isNotFoundError } from "../lib/errors";
@@ -44,21 +44,21 @@ async function getHome(): Promise<string> {
 }
 
 async function getSettingsPath(): Promise<string> {
-  const h = await getHome();
-  return `${h}/Library/Application Support/${APP_NAME}/launcher-settings.json`;
+  const configDir = await appConfigDir();
+  return join(configDir, "launcher-settings.json");
 }
 
 async function getOldSettingsPath(): Promise<string> {
   const h = await getHome();
-  return `${h}/Library/Application Support/${OLD_APP_NAME}/launcher-settings.json`;
+  return join(h, "Library", "Application Support", OLD_APP_NAME, "launcher-settings.json");
 }
 
 async function findGZDoom(): Promise<string | null> {
   const h = await getHome();
   const allLocations = [
     ...GZDOOM_LOCATIONS,
-    `${h}/Applications/UZDoom.app/Contents/MacOS/uzdoom`,
-    `${h}/Applications/GZDoom.app/Contents/MacOS/gzdoom`,
+    await join(h, "Applications", "UZDoom.app", "Contents", "MacOS", "uzdoom"),
+    await join(h, "Applications", "GZDoom.app", "Contents", "MacOS", "gzdoom"),
   ];
   for (const path of allLocations) {
     try {
@@ -93,7 +93,7 @@ async function copyFile(src: string, dest: string): Promise<void> {
 // Populate iwads/ folder from known locations (data folder root, GZDoom folder)
 async function populateIwadsFolder(libraryPath: string): Promise<MigratedIwad[]> {
   const h = await getHome();
-  const iwadsDir = `${libraryPath}/iwads`;
+  const iwadsDir = await join(libraryPath, "iwads");
 
   // Skip if iwads/ already has content
   const existing = await findIwadsInDir(iwadsDir);
@@ -102,7 +102,7 @@ async function populateIwadsFolder(libraryPath: string): Promise<MigratedIwad[]>
   // Source locations (priority order)
   const sources = [
     libraryPath,                                    // Data folder root
-    `${h}/Library/Application Support/gzdoom`,     // GZDoom folder
+    await join(h, "Library", "Application Support", "gzdoom"),     // GZDoom folder
   ];
 
   await mkdir(iwadsDir, { recursive: true });
@@ -113,7 +113,9 @@ async function populateIwadsFolder(libraryPath: string): Promise<MigratedIwad[]>
     const iwads = await findIwadsInDir(srcDir);
     for (const name of iwads) {
       if (copiedNames.map(n => n.toLowerCase()).includes(name.toLowerCase())) continue;
-      await copyFile(`${srcDir}/${name}`, `${iwadsDir}/${name}`);
+      const srcPath = await join(srcDir, name);
+      const destPath = await join(iwadsDir, name);
+      await copyFile(srcPath, destPath);
       copied.push({ name, from: srcDir });
       copiedNames.push(name);
     }
@@ -199,7 +201,7 @@ async function extractFromGOG(
   const extractedWads: string[] = [];
   for (const wad of GOG_IWADS_TO_EXTRACT) {
     try {
-      if (await exists(`${iwadsDir}/${wad}`)) {
+      if (await exists(await join(iwadsDir, wad))) {
         extractedWads.push(wad);
       }
     } catch {
@@ -218,8 +220,8 @@ export function useSettings() {
     if (initialized.value) return;
 
     const h = await getHome();
-    const newConfigDir = `${h}/Library/Application Support/${APP_NAME}`;
-    const newDefaultLibrary = newConfigDir;  // New users get new folder
+    const newConfigDir = await join(h, "Library", "Application Support", APP_NAME);
+    const newDefaultLibrary = await appDataDir();  // New users get app data folder
 
     const newPath = await getSettingsPath();
     const oldPath = await getOldSettingsPath();
@@ -315,7 +317,7 @@ export function useSettings() {
     if (!innoCmd) {
       throw new Error("innoextract not found. Install it with: brew install innoextract");
     }
-    const iwadsDir = `${settings.value.libraryPath}/iwads`;
+    const iwadsDir = await join(settings.value.libraryPath, "iwads");
     return extractFromGOG(installerPath, iwadsDir, innoCmd);
   }
 


### PR DESCRIPTION
## Changes

Of not controversial changes:
- change path calls in TS side to use tauri::fs::path functs.
- add option to select gzdoom image in formats other than .app (.exe and any, with reasonable system-dependent defaults)

Of weird ones:
- moved configuration handling to rust backend. right now it just validates the json schema and jsons it back to frontend. something better shall be done in future.

Of nice ones:
- refactor all paths into related to tauri AppData and AppConfig, and change identifier for them to be compatible with previous versions

## Playtests

It runs on windows and I played a level!
<img width="515" height="469" alt="image" src="https://github.com/user-attachments/assets/41ca887b-8706-46d6-9a4f-bf486333ccd1" />
<img width="642" height="452" alt="image" src="https://github.com/user-attachments/assets/03fc9e18-a672-4e79-9e4b-b41372563bb5" />
<img width="1167" height="573" alt="image" src="https://github.com/user-attachments/assets/b360ebf9-062a-4546-8c91-01759a40d627" />

## Issues:

### ~on second run it loses some permissions~

<img width="1165" height="473" alt="image" src="https://github.com/user-attachments/assets/bd1792ac-cbd2-48f8-bbfe-b5e14141810c" />

### recording logs seems to be dead
<img width="1167" height="573" alt="image" src="https://github.com/user-attachments/assets/6eff6ffd-0488-4009-9c9d-e6f03fc48280" />

