### PR TITLE
Fixed "Open IWAD Folder" regex

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "plugins": {
     "shell": {
-      "open": "^(/|[A-Za-z]:\\\\|https://)"
+      "open": "(/.+|[A-Za-z]:\\\\.+|https://.+)"
     }
   },
   "bundle": {


### PR DESCRIPTION
fix shell:open regex so "Open IWAD Folder" works with real paths.

Was:
<img width="2624" height="1824" alt="Screenshot 2026-04-15 at 23 29 58" src="https://github.com/user-attachments/assets/57fb78d2-1479-46f8-b83d-01413ce09059" />

And now it works.