### PR TITLE
Windows crate migration over direct powershell usage for get_engine_version_impl() and is_process_running_impl()

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-shell",
  "tauri-plugin-upload",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4067,7 +4068,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4138,7 +4139,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4310,7 +4311,7 @@ dependencies = [
  "tokio-tungstenite",
  "uuid",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4376,7 +4377,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4402,7 +4403,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5270,7 +5271,7 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5294,7 +5295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.17",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5350,11 +5351,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5364,6 +5377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5400,7 +5422,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5445,6 +5478,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5594,6 +5637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5822,7 +5874,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-shell",
  "tauri-plugin-upload",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4068,7 +4068,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4139,7 +4139,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "tokio-tungstenite",
  "uuid",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
 ]
 
@@ -4377,7 +4377,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -4403,7 +4403,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -5271,7 +5271,7 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5295,7 +5295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.17",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
 ]
 
@@ -5351,23 +5351,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -5377,15 +5365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5422,18 +5401,7 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5478,16 +5446,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5637,15 +5595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5874,7 +5823,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,8 +26,10 @@ serde_json = "1"
 log = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62.2", features = [
-	"Win32_Foundation",
-	"Win32_Storage_FileSystem",
-	"Win32_System_Diagnostics_ToolHelp",
+# Pinned to 0.61.3 to match the version Tauri itself depends on, avoiding two
+# copies of the windows crate in the lockfile and a larger Windows build.
+windows = { version = "0.61.3", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_ToolHelp",
 ] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,10 @@ tauri-plugin-mcp-bridge = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62.2", features = [
+	"Win32_Foundation",
+	"Win32_Storage_FileSystem",
+	"Win32_System_Diagnostics_ToolHelp",
+] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,9 +8,7 @@ use tauri::Manager;
 pub mod launcher_downloads;
 
 #[tauri::command]
-async fn read_launcher_downloads(
-    library_path: String,
-) -> Result<launcher_downloads::LauncherDownloads, String> {
+async fn read_launcher_downloads(library_path: String) -> Result<launcher_downloads::LauncherDownloads, String> {
     let path = launcher_downloads::launcher_downloads_path(library_path);
     launcher_downloads::read_launcher_downloads_or_empty(path)
 }
@@ -267,7 +265,8 @@ fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
             }
         }
 
-        let _ = CloseHandle(snapshot);
+        CloseHandle(snapshot)
+            .map_err(|e| format!("Failed to close process snapshot handle: {}", e))?;
 
         Ok(found)
     }
@@ -276,7 +275,10 @@ fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
 /// Launch GZDoom/UZDoom with the specified executable path and arguments.
 /// Captures stdout/stderr for later retrieval via get_gzdoom_log.
 #[tauri::command]
-async fn launch_gzdoom(gzdoom_path: String, args: Vec<String>) -> Result<(), String> {
+async fn launch_gzdoom(
+    gzdoom_path: String,
+    args: Vec<String>,
+) -> Result<(), String> {
     // Security: Validate the path looks like a doom engine
     let path_lower = gzdoom_path.to_lowercase();
     if !path_lower.contains("gzdoom") && !path_lower.contains("uzdoom") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,9 @@ use tauri::Manager;
 pub mod launcher_downloads;
 
 #[tauri::command]
-async fn read_launcher_downloads(library_path: String) -> Result<launcher_downloads::LauncherDownloads, String> {
+async fn read_launcher_downloads(
+    library_path: String,
+) -> Result<launcher_downloads::LauncherDownloads, String> {
     let path = launcher_downloads::launcher_downloads_path(library_path);
     launcher_downloads::read_launcher_downloads_or_empty(path)
 }
@@ -111,31 +113,106 @@ fn get_engine_version_impl(engine_path: &str) -> Result<String, String> {
 
 #[cfg(target_os = "windows")]
 fn get_engine_version_impl(engine_path: &str) -> Result<String, String> {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    use std::ffi::c_void;
+    use windows::{
+        Win32::Storage::FileSystem::{
+            GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+        },
+        core::PCWSTR,
+    };
 
-    // Read executable metadata instead of launching the engine.
-    let ps_cmd = format!(
-        "(Get-Item -LiteralPath '{}').VersionInfo.ProductVersion",
-        engine_path.replace('\'', "''")
-    );
+    fn to_wide_null(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
 
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &ps_cmd])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
+    let path_w = to_wide_null(engine_path);
+
+    unsafe {
+        let mut handle = 0u32;
+        let size = GetFileVersionInfoSizeW(PCWSTR(path_w.as_ptr()), Some(&mut handle));
+
+        if size == 0 {
+            return Err("Could not read executable version metadata".to_string());
+        }
+
+        let mut buffer = vec![0u8; size as usize];
+
+        GetFileVersionInfoW(
+            PCWSTR(path_w.as_ptr()),
+            Some(0),
+            size,
+            buffer.as_mut_ptr() as *mut _,
+        )
         .map_err(|e| format!("Failed to query file version: {}", e))?;
 
-    if !output.status.success() {
-        return Err("Could not read executable version metadata".to_string());
-    }
+        let translation_block = to_wide_null(r"\VarFileInfo\Translation");
+        let mut translation_ptr: *mut c_void = std::ptr::null_mut();
+        let mut translation_len: u32 = 0;
 
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if version.is_empty() {
-        return Err("Executable version metadata is empty".to_string());
-    }
+        if !VerQueryValueW(
+            buffer.as_ptr() as *const _,
+            PCWSTR(translation_block.as_ptr()),
+            &mut translation_ptr,
+            &mut translation_len,
+        )
+        .as_bool()
+        {
+            return Err("Failed to query translation info".to_string());
+        }
 
-    Ok(version)
+        if translation_ptr.is_null() || translation_len < 4 {
+            return Err("Executable version translation info is missing".to_string());
+        }
+
+        let translation = std::slice::from_raw_parts(
+            translation_ptr as *const u16,
+            (translation_len / 2) as usize,
+        );
+
+        if translation.len() < 2 {
+            return Err("Executable version translation info is invalid".to_string());
+        }
+
+        let lang = translation[0];
+        let codepage = translation[1];
+
+        let sub_block = format!(
+            r"\StringFileInfo\{:04x}{:04x}\ProductVersion",
+            lang, codepage
+        );
+        let sub_block_w = to_wide_null(&sub_block);
+
+        let mut value_ptr: *mut c_void = std::ptr::null_mut();
+        let mut value_len: u32 = 0;
+
+        if !VerQueryValueW(
+            buffer.as_ptr() as *const _,
+            PCWSTR(sub_block_w.as_ptr()),
+            &mut value_ptr,
+            &mut value_len,
+        )
+        .as_bool()
+        {
+            return Err("Failed to query ProductVersion".to_string());
+        }
+
+        if value_ptr.is_null() || value_len == 0 {
+            return Err("Executable version metadata is empty".to_string());
+        }
+
+        let utf16_slice = std::slice::from_raw_parts(value_ptr as *const u16, value_len as usize);
+
+        let version = String::from_utf16_lossy(utf16_slice)
+            .trim_end_matches('\0')
+            .trim()
+            .to_string();
+
+        if version.is_empty() {
+            return Err("Executable version metadata is empty".to_string());
+        }
+
+        Ok(version)
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -150,32 +227,56 @@ fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
 
 #[cfg(target_os = "windows")]
 fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+        TH32CS_SNAPPROCESS,
+    };
 
-    let filter = format!("IMAGENAME eq {}", process_name);
+    let target = process_name.to_lowercase();
 
-    let output = Command::new("tasklist")
-        .args(["/FI", &filter])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("Failed to run tasklist: {}", e))?;
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+            .map_err(|e| format!("Failed to create process snapshot: {}", e))?;
 
-    if !output.status.success() {
-        return Err("tasklist failed".to_string());
+        let mut entry = PROCESSENTRY32W::default();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+
+        let mut found = false;
+
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let exe_name = String::from_utf16_lossy(
+                    &entry
+                        .szExeFile
+                        .iter()
+                        .take_while(|&&c| c != 0)
+                        .copied()
+                        .collect::<Vec<u16>>(),
+                )
+                .to_lowercase();
+
+                if exe_name == target {
+                    found = true;
+                    break;
+                }
+
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+
+        Ok(found)
     }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_lowercase();
-    Ok(stdout.contains(&process_name.to_lowercase()))
 }
 
 /// Launch GZDoom/UZDoom with the specified executable path and arguments.
 /// Captures stdout/stderr for later retrieval via get_gzdoom_log.
 #[tauri::command]
-async fn launch_gzdoom(
-    gzdoom_path: String,
-    args: Vec<String>,
-) -> Result<(), String> {
+async fn launch_gzdoom(gzdoom_path: String, args: Vec<String>) -> Result<(), String> {
     // Security: Validate the path looks like a doom engine
     let path_lower = gzdoom_path.to_lowercase();
     if !path_lower.contains("gzdoom") && !path_lower.contains("uzdoom") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,9 @@ use tauri::Manager;
 pub mod launcher_downloads;
 
 #[tauri::command]
-async fn read_launcher_downloads(library_path: String) -> Result<launcher_downloads::LauncherDownloads, String> {
+async fn read_launcher_downloads(
+    library_path: String,
+) -> Result<launcher_downloads::LauncherDownloads, String> {
     let path = launcher_downloads::launcher_downloads_path(library_path);
     launcher_downloads::read_launcher_downloads_or_empty(path)
 }
@@ -111,26 +113,106 @@ fn get_engine_version_impl(engine_path: &str) -> Result<String, String> {
 
 #[cfg(target_os = "windows")]
 fn get_engine_version_impl(engine_path: &str) -> Result<String, String> {
-    // Read executable metadata instead of launching the engine.
-    let ps_cmd = format!(
-        "(Get-Item -LiteralPath '{}').VersionInfo.ProductVersion",
-        engine_path.replace('\'', "''")
-    );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &ps_cmd])
-        .output()
+    use std::ffi::c_void;
+    use windows::{
+        Win32::Storage::FileSystem::{
+            GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+        },
+        core::PCWSTR,
+    };
+
+    fn to_wide_null(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    let path_w = to_wide_null(engine_path);
+
+    unsafe {
+        let mut handle = 0u32;
+        let size = GetFileVersionInfoSizeW(PCWSTR(path_w.as_ptr()), Some(&mut handle));
+
+        if size == 0 {
+            return Err("Could not read executable version metadata".to_string());
+        }
+
+        let mut buffer = vec![0u8; size as usize];
+
+        GetFileVersionInfoW(
+            PCWSTR(path_w.as_ptr()),
+            Some(0),
+            size,
+            buffer.as_mut_ptr() as *mut _,
+        )
         .map_err(|e| format!("Failed to query file version: {}", e))?;
 
-    if !output.status.success() {
-        return Err("Could not read executable version metadata".to_string());
-    }
+        let translation_block = to_wide_null(r"\VarFileInfo\Translation");
+        let mut translation_ptr: *mut c_void = std::ptr::null_mut();
+        let mut translation_len: u32 = 0;
 
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if version.is_empty() {
-        return Err("Executable version metadata is empty".to_string());
-    }
+        if !VerQueryValueW(
+            buffer.as_ptr() as *const _,
+            PCWSTR(translation_block.as_ptr()),
+            &mut translation_ptr,
+            &mut translation_len,
+        )
+        .as_bool()
+        {
+            return Err("Failed to query translation info".to_string());
+        }
 
-    Ok(version)
+        if translation_ptr.is_null() || translation_len < 4 {
+            return Err("Executable version translation info is missing".to_string());
+        }
+
+        let translation = std::slice::from_raw_parts(
+            translation_ptr as *const u16,
+            (translation_len / 2) as usize,
+        );
+
+        if translation.len() < 2 {
+            return Err("Executable version translation info is invalid".to_string());
+        }
+
+        let lang = translation[0];
+        let codepage = translation[1];
+
+        let sub_block = format!(
+            r"\StringFileInfo\{:04x}{:04x}\ProductVersion",
+            lang, codepage
+        );
+        let sub_block_w = to_wide_null(&sub_block);
+
+        let mut value_ptr: *mut c_void = std::ptr::null_mut();
+        let mut value_len: u32 = 0;
+
+        if !VerQueryValueW(
+            buffer.as_ptr() as *const _,
+            PCWSTR(sub_block_w.as_ptr()),
+            &mut value_ptr,
+            &mut value_len,
+        )
+        .as_bool()
+        {
+            return Err("Failed to query ProductVersion".to_string());
+        }
+
+        if value_ptr.is_null() || value_len == 0 {
+            return Err("Executable version metadata is empty".to_string());
+        }
+
+        let utf16_slice = std::slice::from_raw_parts(value_ptr as *const u16, value_len as usize);
+
+        let version = String::from_utf16_lossy(utf16_slice)
+            .trim_end_matches('\0')
+            .trim()
+            .to_string();
+
+        if version.is_empty() {
+            return Err("Executable version metadata is empty".to_string());
+        }
+
+        Ok(version)
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -145,27 +227,56 @@ fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
 
 #[cfg(target_os = "windows")]
 fn is_process_running_impl(process_name: &str) -> Result<bool, String> {
-    let filter = format!("IMAGENAME eq {}", process_name);
-    let output = Command::new("tasklist")
-        .args(["/FI", &filter])
-        .output()
-        .map_err(|e| format!("Failed to run tasklist: {}", e))?;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+        TH32CS_SNAPPROCESS,
+    };
 
-    if !output.status.success() {
-        return Err("tasklist failed".to_string());
+    let target = process_name.to_lowercase();
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+            .map_err(|e| format!("Failed to create process snapshot: {}", e))?;
+
+        let mut entry = PROCESSENTRY32W::default();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+
+        let mut found = false;
+
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let exe_name = String::from_utf16_lossy(
+                    &entry
+                        .szExeFile
+                        .iter()
+                        .take_while(|&&c| c != 0)
+                        .copied()
+                        .collect::<Vec<u16>>(),
+                )
+                .to_lowercase();
+
+                if exe_name == target {
+                    found = true;
+                    break;
+                }
+
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+
+        Ok(found)
     }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_lowercase();
-    Ok(stdout.contains(&process_name.to_lowercase()))
 }
 
 /// Launch GZDoom/UZDoom with the specified executable path and arguments.
 /// Captures stdout/stderr for later retrieval via get_gzdoom_log.
 #[tauri::command]
-async fn launch_gzdoom(
-    gzdoom_path: String,
-    args: Vec<String>,
-) -> Result<(), String> {
+async fn launch_gzdoom(gzdoom_path: String, args: Vec<String>) -> Result<(), String> {
     // Security: Validate the path looks like a doom engine
     let path_lower = gzdoom_path.to_lowercase();
     if !path_lower.contains("gzdoom") && !path_lower.contains("uzdoom") {


### PR DESCRIPTION
This PR removes the PowerShell stuff from get_engine_version_impl() and is_process_running_impl() and replaces it with native Windows API calls using the windows crate.

Mainly did this to avoid spawning PowerShell every time, which was slow and kinda messy. This should be faster and cleaner

Functionality should be the same, I just implemented in a better way.

I also added the dependency as a platform specific dependency.

Sorry about the unnecessary formatting. My code editor seems to be doing that.