### PR TITLE
Stream zip handling in Rust; keep bulk bytes out of the webview

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -878,6 +878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1868,6 +1869,15 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3326,6 +3336,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-upload",
  "windows",
+ "zip",
 ]
 
 [[package]]
@@ -4751,6 +4762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,6 +5917,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.1",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-upload = "2"
 tauri-plugin-mcp-bridge = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # Pinned to 0.61.3 to match the version Tauri itself depends on, avoiding two

--- a/src-tauri/src/game_archives.rs
+++ b/src-tauri/src/game_archives.rs
@@ -1,0 +1,303 @@
+// Streaming archive operations for downloaded WADs/mods and custom imports.
+//
+// Bulk archive bytes must stay out of the webview: WebKit kills the
+// WebContent process when it balloons (a 500 MB mod zip read there costs
+// ~3 GB RSS). The frontend gets entry listings and small size-capped
+// entries; everything else streams disk-to-disk here.
+
+use serde::Serialize;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+use zip::ZipArchive;
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipEntryInfo {
+    pub path: String,
+    pub size: u64,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractedGameFile {
+    pub name: String,
+    pub size: u64,
+}
+
+fn open_archive(zip_path: &str) -> Result<ZipArchive<File>, String> {
+    let file =
+        File::open(zip_path).map_err(|e| format!("Failed to open {}: {}", zip_path, e))?;
+    ZipArchive::new(file).map_err(|e| format!("Failed to read ZIP {}: {}", zip_path, e))
+}
+
+/// Basename of a zip entry path. Entry names use `/`, but Windows-created
+/// archives sometimes carry `\`. Basename-only also rules out zip-slip.
+fn basename(entry_path: &str) -> &str {
+    entry_path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(entry_path)
+}
+
+fn is_game_file(entry_path: &str) -> bool {
+    let lower = entry_path.to_lowercase();
+    lower.ends_with(".wad") || lower.ends_with(".pk3")
+}
+
+/// Check magic bytes of a downloaded file without reading it whole.
+/// `filename` decides the expected format by extension.
+pub fn validate_game_file(path: &str, filename: &str) -> Result<(), String> {
+    let ext = filename
+        .to_lowercase()
+        .rsplit('.')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+
+    let mut file = File::open(path).map_err(|e| format!("Failed to open {}: {}", path, e))?;
+    let file_len = file
+        .metadata()
+        .map_err(|e| format!("Failed to stat {}: {}", path, e))?
+        .len();
+    let mut magic = [0u8; 4];
+    let read = file
+        .read(&mut magic)
+        .map_err(|e| format!("Failed to read {}: {}", path, e))?;
+
+    match ext.as_str() {
+        "zip" | "pk3" => {
+            if read < 2 || magic[0] != 0x50 || magic[1] != 0x4b {
+                return Err(format!(
+                    "Invalid ZIP file: {} - file appears corrupted or is not a ZIP archive (got {} bytes, magic: {:02x} {:02x})",
+                    filename, file_len, magic[0], magic[1]
+                ));
+            }
+        }
+        "wad" => {
+            if read < 4 {
+                return Err(format!(
+                    "Invalid WAD file: {} - file too small ({} bytes)",
+                    filename, file_len
+                ));
+            }
+            if &magic != b"IWAD" && &magic != b"PWAD" {
+                return Err(format!(
+                    "Invalid WAD file: {} - expected IWAD/PWAD header, got \"{}\"",
+                    filename,
+                    String::from_utf8_lossy(&magic)
+                ));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Stream every .wad/.pk3 inside a zip to `dest_dir` (basename only).
+/// Returns name+size per extracted file; the frontend picks the primary.
+pub fn extract_game_files(zip_path: &str, dest_dir: &str) -> Result<Vec<ExtractedGameFile>, String> {
+    std::fs::create_dir_all(dest_dir)
+        .map_err(|e| format!("Failed to create {}: {}", dest_dir, e))?;
+    let mut archive = open_archive(zip_path)?;
+    let mut extracted = Vec::new();
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("Failed to read ZIP entry #{}: {}", i, e))?;
+        if entry.is_dir() || !is_game_file(entry.name()) {
+            continue;
+        }
+        let name = basename(entry.name()).to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let dest_path = Path::new(dest_dir).join(&name);
+        let mut out = File::create(&dest_path)
+            .map_err(|e| format!("Failed to create {}: {}", dest_path.display(), e))?;
+        let size = io::copy(&mut entry, &mut out)
+            .map_err(|e| format!("Failed to extract {}: {}", name, e))?;
+        extracted.push(ExtractedGameFile { name, size });
+    }
+
+    if extracted.is_empty() {
+        return Err("No WAD or PK3 files found inside ZIP archive".to_string());
+    }
+    Ok(extracted)
+}
+
+/// Stream a single zip entry to `dest_path`. Returns bytes written.
+pub fn extract_zip_entry(zip_path: &str, entry_path: &str, dest_path: &str) -> Result<u64, String> {
+    let mut archive = open_archive(zip_path)?;
+    let mut entry = archive
+        .by_name(entry_path)
+        .map_err(|e| format!("Entry {} not found in {}: {}", entry_path, zip_path, e))?;
+    let mut out = File::create(dest_path)
+        .map_err(|e| format!("Failed to create {}: {}", dest_path, e))?;
+    io::copy(&mut entry, &mut out).map_err(|e| format!("Failed to extract {}: {}", entry_path, e))
+}
+
+/// List file entries (path + uncompressed size). Directories are skipped.
+pub fn list_zip_entries(zip_path: &str) -> Result<Vec<ZipEntryInfo>, String> {
+    let mut archive = open_archive(zip_path)?;
+    let mut entries = Vec::with_capacity(archive.len());
+    for i in 0..archive.len() {
+        let entry = archive
+            .by_index(i)
+            .map_err(|e| format!("Failed to read ZIP entry #{}: {}", i, e))?;
+        if entry.is_dir() {
+            continue;
+        }
+        entries.push(ZipEntryInfo {
+            path: entry.name().to_string(),
+            size: entry.size(),
+        });
+    }
+    Ok(entries)
+}
+
+/// Read one entry into memory, refusing anything over `max_bytes`.
+pub fn read_zip_entry(zip_path: &str, entry_path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+    let mut archive = open_archive(zip_path)?;
+    let mut entry = archive
+        .by_name(entry_path)
+        .map_err(|e| format!("Entry {} not found in {}: {}", entry_path, zip_path, e))?;
+    if entry.size() > max_bytes {
+        return Err(format!(
+            "Zip entry {} is too large to read into memory ({} bytes, cap {} bytes)",
+            entry_path,
+            entry.size(),
+            max_bytes
+        ));
+    }
+    let mut buf = Vec::with_capacity(entry.size() as usize);
+    entry
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("Failed to read {}: {}", entry_path, e))?;
+    Ok(buf)
+}
+
+/// Read a whole file into memory, refusing anything over `max_bytes`.
+pub fn read_file_capped(path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+    let meta =
+        std::fs::metadata(path).map_err(|e| format!("Failed to stat {}: {}", path, e))?;
+    if meta.len() > max_bytes {
+        return Err(format!(
+            "File is too large to inspect ({} bytes, cap {} bytes)",
+            meta.len(),
+            max_bytes
+        ));
+    }
+    std::fs::read(path).map_err(|e| format!("Failed to read {}: {}", path, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("game_archives_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    fn make_zip(name: &str, entries: &[(&str, &[u8])]) -> String {
+        let path = temp_path(name);
+        let file = File::create(&path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        for (entry_name, data) in entries {
+            writer
+                .start_file(*entry_name, SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(data).unwrap();
+        }
+        writer.finish().unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn extracts_wad_and_pk3_stripping_directories() {
+        let zip = make_zip(
+            "extract.zip",
+            &[
+                ("readme.txt", b"hello"),
+                ("nested/dir/MyMod.pk3", b"PK\x03\x04pk3data"),
+                ("maps.WAD", b"PWADxxxx"),
+            ],
+        );
+        let dest = temp_path("extract_out");
+        let mut files = extract_game_files(&zip, dest.to_str().unwrap()).unwrap();
+        files.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(
+            files,
+            vec![
+                ExtractedGameFile { name: "MyMod.pk3".into(), size: 11 },
+                ExtractedGameFile { name: "maps.WAD".into(), size: 8 },
+            ]
+        );
+        assert_eq!(std::fs::read(dest.join("maps.WAD")).unwrap(), b"PWADxxxx");
+    }
+
+    #[test]
+    fn extract_errors_when_no_game_files() {
+        let zip = make_zip("nogame.zip", &[("readme.txt", b"hello")]);
+        let dest = temp_path("nogame_out");
+        let err = extract_game_files(&zip, dest.to_str().unwrap()).unwrap_err();
+        assert_eq!(err, "No WAD or PK3 files found inside ZIP archive");
+    }
+
+    #[test]
+    fn lists_entries_with_sizes() {
+        let zip = make_zip("list.zip", &[("a.txt", b"12345"), ("dir/b.wad", b"PWAD")]);
+        let entries = list_zip_entries(&zip).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                ZipEntryInfo { path: "a.txt".into(), size: 5 },
+                ZipEntryInfo { path: "dir/b.wad".into(), size: 4 },
+            ]
+        );
+    }
+
+    #[test]
+    fn read_entry_respects_cap() {
+        let zip = make_zip("cap.zip", &[("big.bin", &[0u8; 1024])]);
+        assert!(read_zip_entry(&zip, "big.bin", 1024).is_ok());
+        let err = read_zip_entry(&zip, "big.bin", 1023).unwrap_err();
+        assert!(err.contains("too large"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn extract_single_entry_streams_to_dest() {
+        let zip = make_zip("single.zip", &[("inner/file.pk3", b"PK\x03\x04abc")]);
+        let dest = temp_path("single_out.pk3");
+        let written = extract_zip_entry(&zip, "inner/file.pk3", dest.to_str().unwrap()).unwrap();
+        assert_eq!(written, 7);
+        assert_eq!(std::fs::read(&dest).unwrap(), b"PK\x03\x04abc");
+    }
+
+    #[test]
+    fn validates_magic_bytes_per_extension() {
+        let zip_ok = temp_path("v1.zip");
+        std::fs::write(&zip_ok, b"PK\x03\x04rest").unwrap();
+        assert!(validate_game_file(zip_ok.to_str().unwrap(), "v1.zip").is_ok());
+
+        let zip_bad = temp_path("v2.zip");
+        std::fs::write(&zip_bad, b"<html>not a zip").unwrap();
+        let err = validate_game_file(zip_bad.to_str().unwrap(), "v2.zip").unwrap_err();
+        assert!(err.contains("Invalid ZIP file"), "{}", err);
+
+        let wad_ok = temp_path("v3.wad");
+        std::fs::write(&wad_ok, b"IWADxxxxxxxx").unwrap();
+        assert!(validate_game_file(wad_ok.to_str().unwrap(), "v3.wad").is_ok());
+
+        let wad_bad = temp_path("v4.wad");
+        std::fs::write(&wad_bad, b"JUNKxxxxxxxx").unwrap();
+        let err = validate_game_file(wad_bad.to_str().unwrap(), "v4.wad").unwrap_err();
+        assert!(err.contains("expected IWAD/PWAD header"), "{}", err);
+    }
+}

--- a/src-tauri/src/game_archives.rs
+++ b/src-tauri/src/game_archives.rs
@@ -158,20 +158,12 @@ pub fn list_zip_entries(zip_path: &str) -> Result<Vec<ZipEntryInfo>, String> {
     Ok(entries)
 }
 
-/// Read one entry into memory, refusing anything over `max_bytes`.
-pub fn read_zip_entry(zip_path: &str, entry_path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+/// Read one entry into memory.
+pub fn read_zip_entry(zip_path: &str, entry_path: &str) -> Result<Vec<u8>, String> {
     let mut archive = open_archive(zip_path)?;
     let mut entry = archive
         .by_name(entry_path)
         .map_err(|e| format!("Entry {} not found in {}: {}", entry_path, zip_path, e))?;
-    if entry.size() > max_bytes {
-        return Err(format!(
-            "Zip entry {} is too large to read into memory ({} bytes, cap {} bytes)",
-            entry_path,
-            entry.size(),
-            max_bytes
-        ));
-    }
     let mut buf = Vec::with_capacity(entry.size() as usize);
     entry
         .read_to_end(&mut buf)
@@ -179,18 +171,41 @@ pub fn read_zip_entry(zip_path: &str, entry_path: &str, max_bytes: u64) -> Resul
     Ok(buf)
 }
 
-/// Read a whole file into memory, refusing anything over `max_bytes`.
-pub fn read_file_capped(path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
-    let meta =
-        std::fs::metadata(path).map_err(|e| format!("Failed to stat {}: {}", path, e))?;
-    if meta.len() > max_bytes {
-        return Err(format!(
-            "File is too large to inspect ({} bytes, cap {} bytes)",
-            meta.len(),
-            max_bytes
-        ));
-    }
-    std::fs::read(path).map_err(|e| format!("Failed to read {}: {}", path, e))
+/// Stream a zip entry into a fresh temp directory and return its path.
+/// Used at pick time in the custom-mod importer so inspection and the
+/// eventual copy into the library work from a real, seekable file.
+pub fn extract_zip_entry_to_temp(zip_path: &str, entry_path: &str) -> Result<String, String> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("System clock error: {}", e))?
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "rusted-doom-launcher-{}-{}",
+        std::process::id(),
+        nanos
+    ));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {}: {}", dir.display(), e))?;
+    let dest = dir.join(basename(entry_path));
+    let dest_str = dest.to_string_lossy().to_string();
+    extract_zip_entry(zip_path, entry_path, &dest_str)?;
+    Ok(dest_str)
+}
+
+/// Read `len` bytes at `offset` from a file. Errors if the range is out of
+/// bounds — short reads never succeed silently.
+pub fn read_file_range(path: &str, offset: u64, len: u64) -> Result<Vec<u8>, String> {
+    use std::io::{Seek, SeekFrom};
+    let mut file = File::open(path).map_err(|e| format!("Failed to open {}: {}", path, e))?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| format!("Failed to seek {} to {}: {}", path, offset, e))?;
+    let mut buf = vec![0u8; len as usize];
+    file.read_exact(&mut buf).map_err(|e| {
+        format!(
+            "Failed to read {} bytes at offset {} from {}: {}",
+            len, offset, path, e
+        )
+    })?;
+    Ok(buf)
 }
 
 #[cfg(test)]
@@ -264,11 +279,28 @@ mod tests {
     }
 
     #[test]
-    fn read_entry_respects_cap() {
-        let zip = make_zip("cap.zip", &[("big.bin", &[0u8; 1024])]);
-        assert!(read_zip_entry(&zip, "big.bin", 1024).is_ok());
-        let err = read_zip_entry(&zip, "big.bin", 1023).unwrap_err();
-        assert!(err.contains("too large"), "unexpected error: {}", err);
+    fn reads_single_entry() {
+        let zip = make_zip("entry.zip", &[("dir/notes.txt", b"hello world")]);
+        assert_eq!(read_zip_entry(&zip, "dir/notes.txt").unwrap(), b"hello world");
+        assert!(read_zip_entry(&zip, "missing.txt").is_err());
+    }
+
+    #[test]
+    fn reads_file_range_and_errors_out_of_bounds() {
+        let path = temp_path("range.bin");
+        std::fs::write(&path, b"0123456789").unwrap();
+        let p = path.to_str().unwrap();
+        assert_eq!(read_file_range(p, 2, 4).unwrap(), b"2345");
+        assert_eq!(read_file_range(p, 0, 0).unwrap(), b"");
+        assert!(read_file_range(p, 8, 4).is_err());
+    }
+
+    #[test]
+    fn extracts_entry_to_temp_file() {
+        let zip = make_zip("totemp.zip", &[("inner/mod.pk3", b"PK\x03\x04abc")]);
+        let temp = extract_zip_entry_to_temp(&zip, "inner/mod.pk3").unwrap();
+        assert!(temp.ends_with("mod.pk3"), "{}", temp);
+        assert_eq!(std::fs::read(&temp).unwrap(), b"PK\x03\x04abc");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use tauri::Manager;
 
+pub mod game_archives;
 pub mod launcher_downloads;
 
 #[tauri::command]
@@ -32,12 +33,56 @@ async fn import_custom_wad(source_path: String, target_path: String) -> Result<u
 }
 
 /// Read a user-picked file into memory for inspection. Bypasses fs:scope.
-/// Used by the custom-WAD importer to peek at WAD header / PK3 zip directory
-/// before copying the file into the library.
+/// Used by the custom-WAD importer to peek at a bare .wad before copying
+/// it into the library.
 #[tauri::command]
-async fn read_file_for_inspection(source_path: String) -> Result<Vec<u8>, String> {
-    std::fs::read(&source_path)
-        .map_err(|e| format!("Failed to read {}: {}", source_path, e))
+async fn read_file_for_inspection(
+    source_path: String,
+    max_bytes: u64,
+) -> Result<tauri::ipc::Response, String> {
+    game_archives::read_file_capped(&source_path, max_bytes).map(tauri::ipc::Response::new)
+}
+
+/// Streaming magic-byte check of a downloaded file (no full read).
+#[tauri::command]
+async fn validate_game_file(path: String, filename: String) -> Result<(), String> {
+    game_archives::validate_game_file(&path, &filename)
+}
+
+/// Stream all .wad/.pk3 entries of a zip into the library dir.
+#[tauri::command]
+async fn extract_game_files(
+    zip_path: String,
+    dest_dir: String,
+) -> Result<Vec<game_archives::ExtractedGameFile>, String> {
+    game_archives::extract_game_files(&zip_path, &dest_dir)
+}
+
+/// Stream one zip entry to a destination path. Bypasses fs:scope (the
+/// source is a user-picked zip anywhere on disk).
+#[tauri::command]
+async fn extract_zip_entry(
+    zip_path: String,
+    entry_path: String,
+    dest_path: String,
+) -> Result<u64, String> {
+    game_archives::extract_zip_entry(&zip_path, &entry_path, &dest_path)
+}
+
+/// List zip entries (path + uncompressed size) without reading contents.
+#[tauri::command]
+async fn list_zip_entries(zip_path: String) -> Result<Vec<game_archives::ZipEntryInfo>, String> {
+    game_archives::list_zip_entries(&zip_path)
+}
+
+/// Read a single zip entry as raw bytes. Errors if it exceeds `max_bytes`.
+#[tauri::command]
+async fn read_zip_entry(
+    zip_path: String,
+    entry_path: String,
+    max_bytes: u64,
+) -> Result<tauri::ipc::Response, String> {
+    game_archives::read_zip_entry(&zip_path, &entry_path, max_bytes).map(tauri::ipc::Response::new)
 }
 
 /// Look for an idgames-style metadata sidecar next to a user-picked file.
@@ -478,7 +523,12 @@ pub fn run() {
             read_file_for_inspection,
             read_sibling_text,
             read_custom_wads,
-            write_custom_wads
+            write_custom_wads,
+            validate_game_file,
+            extract_game_files,
+            extract_zip_entry,
+            list_zip_entries,
+            read_zip_entry
         ]);
 
     // MCP bridge for Claude Code debugging (dev mode only)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,15 +32,16 @@ async fn import_custom_wad(source_path: String, target_path: String) -> Result<u
         .map_err(|e| format!("Failed to copy {} -> {}: {}", source_path, target_path, e))
 }
 
-/// Read a user-picked file into memory for inspection. Bypasses fs:scope.
-/// Used by the custom-WAD importer to peek at a bare .wad before copying
-/// it into the library.
+/// Read a byte range from a file. Bypasses fs:scope so the custom-WAD
+/// importer can inspect user-picked files (WAD header, directory, lumps)
+/// without ever reading them whole.
 #[tauri::command]
-async fn read_file_for_inspection(
-    source_path: String,
-    max_bytes: u64,
+async fn read_file_range(
+    path: String,
+    offset: u64,
+    len: u64,
 ) -> Result<tauri::ipc::Response, String> {
-    game_archives::read_file_capped(&source_path, max_bytes).map(tauri::ipc::Response::new)
+    game_archives::read_file_range(&path, offset, len).map(tauri::ipc::Response::new)
 }
 
 /// Streaming magic-byte check of a downloaded file (no full read).
@@ -58,31 +59,25 @@ async fn extract_game_files(
     game_archives::extract_game_files(&zip_path, &dest_dir)
 }
 
-/// Stream one zip entry to a destination path. Bypasses fs:scope (the
-/// source is a user-picked zip anywhere on disk).
-#[tauri::command]
-async fn extract_zip_entry(
-    zip_path: String,
-    entry_path: String,
-    dest_path: String,
-) -> Result<u64, String> {
-    game_archives::extract_zip_entry(&zip_path, &entry_path, &dest_path)
-}
-
 /// List zip entries (path + uncompressed size) without reading contents.
 #[tauri::command]
 async fn list_zip_entries(zip_path: String) -> Result<Vec<game_archives::ZipEntryInfo>, String> {
     game_archives::list_zip_entries(&zip_path)
 }
 
-/// Read a single zip entry as raw bytes. Errors if it exceeds `max_bytes`.
+/// Read a single zip entry as raw bytes.
 #[tauri::command]
 async fn read_zip_entry(
     zip_path: String,
     entry_path: String,
-    max_bytes: u64,
 ) -> Result<tauri::ipc::Response, String> {
-    game_archives::read_zip_entry(&zip_path, &entry_path, max_bytes).map(tauri::ipc::Response::new)
+    game_archives::read_zip_entry(&zip_path, &entry_path).map(tauri::ipc::Response::new)
+}
+
+/// Stream a zip entry to a temp file and return its path. Bypasses fs:scope.
+#[tauri::command]
+async fn extract_zip_entry_to_temp(zip_path: String, entry_path: String) -> Result<String, String> {
+    game_archives::extract_zip_entry_to_temp(&zip_path, &entry_path)
 }
 
 /// Look for an idgames-style metadata sidecar next to a user-picked file.
@@ -520,13 +515,13 @@ pub fn run() {
             read_launcher_downloads,
             write_launcher_downloads,
             import_custom_wad,
-            read_file_for_inspection,
+            read_file_range,
             read_sibling_text,
             read_custom_wads,
             write_custom_wads,
             validate_game_file,
             extract_game_files,
-            extract_zip_entry,
+            extract_zip_entry_to_temp,
             list_zip_entries,
             read_zip_entry
         ]);

--- a/src/components/CustomModView.vue
+++ b/src/components/CustomModView.vue
@@ -2,15 +2,19 @@
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
-import { stat, exists, writeFile } from "@tauri-apps/plugin-fs";
+import { stat, exists } from "@tauri-apps/plugin-fs";
 import { WadEntrySchema, type WadEntry, type Iwad } from "../lib/schema";
 import { useLibrary } from "../composables/useLibrary";
 import { useDownload } from "../composables/useDownload";
 import { useCustomWads } from "../composables/useCustomWads";
 import { useSettings } from "../composables/useSettings";
-import { inspectFile, parseInfoText, type FileInspection } from "../lib/wadInspect";
-import { findGameFilesInZip, selectPrimaryGameFile } from "../lib/zipExtract";
-import { strFromU8 } from "fflate";
+import { inspectFile, inspectPk3FromArchive, fallbackInspection, parseInfoText, type FileInspection } from "../lib/wadInspect";
+import { findGameFileEntries, selectPrimaryGameFile, type ZipEntryInfo } from "../lib/zipExtract";
+
+// Largest file we'll read into memory to inspect. Bigger files still
+// import fine; they just skip the metadata pre-fill.
+const MAX_INSPECT_BYTES = 128 * 1024 * 1024;
+const MAX_SIDECAR_TXT_BYTES = 4 * 1024 * 1024;
 
 const props = defineProps<{
   defaultType: WadEntry["type"];
@@ -139,10 +143,10 @@ const errorMsg = ref<string>("");
 const submitting = ref(false);
 const inspection = ref<FileInspection | null>(null);
 const inspecting = ref(false);
-// When user picks a .zip bundle, we hold the extracted inner .wad/.pk3 bytes
-// here so onSubmit can write them to the library (vs. file-to-file copy used
+// When user picks a .zip bundle, we remember which entry inside it is the
+// game file so onSubmit can stream-extract it (vs. file-to-file copy used
 // for bare .wad/.pk3). innerName is the basename we'll save as.
-const pickedZip = ref<{ innerName: string; innerBytes: Uint8Array } | null>(null);
+const pickedZip = ref<{ innerName: string; entryPath: string; size: number } | null>(null);
 
 const pickerOpen = ref(false);
 const pickerRef = ref<HTMLElement | null>(null);
@@ -295,39 +299,68 @@ async function pickFile() {
   pickedZip.value = null;
   inspecting.value = true;
   try {
-    const sourceBytes = await invoke<number[]>("read_file_for_inspection", { sourcePath: picked });
     const sourceBasename = basenameOf(picked);
     const sourceExt = sourceBasename.toLowerCase().split(".").pop() ?? "";
 
-    // What we inspect (and ultimately copy into the library) depends on whether
-    // the picked file is a raw .wad/.pk3 or a .zip bundle that contains one.
+    // What we inspect (and ultimately copy into the library) depends on
+    // whether the picked file is a raw .wad/.pk3 or a .zip bundle that
+    // contains one.
     let innerName = sourceBasename;
-    let innerBytes = new Uint8Array(sourceBytes);
     let zipSidecarText = "";
+    let info: FileInspection;
 
     if (sourceExt === "zip") {
-      const zipBytes = new Uint8Array(sourceBytes);
-      const gameFiles = findGameFilesInZip(zipBytes);  // throws if none
+      const entries = await invoke<ZipEntryInfo[]>("list_zip_entries", { zipPath: picked });
+      const gameFiles = findGameFileEntries(entries);  // throws if none
       const { primary } = selectPrimaryGameFile(gameFiles);
       innerName = primary.name;
-      innerBytes = primary.data;
+      pickedZip.value = { innerName, entryPath: primary.path, size: primary.size };
+
       // Read any .txt at the zip root (the idgames upload-template sidecar).
       // We scan all entries since "Beautiful Doom" style PK3s nest the .txt
       // inside a single folder.
-      const { unzipSync } = await import("fflate");
-      const entries = unzipSync(zipBytes);
-      for (const [path, data] of Object.entries(entries)) {
-        if (!path.toLowerCase().endsWith(".txt")) continue;
-        const text = strFromU8(data);
+      for (const entry of entries) {
+        if (!entry.path.toLowerCase().endsWith(".txt")) continue;
+        if (entry.size > MAX_SIDECAR_TXT_BYTES) continue;
+        const buf = await invoke<ArrayBuffer>("read_zip_entry", {
+          zipPath: picked,
+          entryPath: entry.path,
+          maxBytes: MAX_SIDECAR_TXT_BYTES,
+        });
+        const text = new TextDecoder().decode(new Uint8Array(buf));
         if (/^\s*Title\s*:/im.test(text) || /^\s*Authors?\s*:/im.test(text)) {
           zipSidecarText = text;
           break;
         }
       }
-      pickedZip.value = { innerName, innerBytes };
+
+      if (primary.size <= MAX_INSPECT_BYTES) {
+        const buf = await invoke<ArrayBuffer>("read_zip_entry", {
+          zipPath: picked,
+          entryPath: primary.path,
+          maxBytes: MAX_INSPECT_BYTES,
+        });
+        info = await inspectFile(innerName, new Uint8Array(buf));
+      } else {
+        console.warn(`[CustomModView] ${innerName} too large to inspect (${primary.size} bytes)`);
+        info = fallbackInspection(innerName.toLowerCase().endsWith(".pk3") ? "pk3" : "wad");
+      }
+    } else if (sourceExt === "pk3") {
+      info = await inspectPk3FromArchive(picked);
+    } else {
+      try {
+        const buf = await invoke<ArrayBuffer>("read_file_for_inspection", {
+          sourcePath: picked,
+          maxBytes: MAX_INSPECT_BYTES,
+        });
+        info = await inspectFile(sourceBasename, new Uint8Array(buf));
+      } catch (e) {
+        if (!String(e).includes("too large to inspect")) throw e;
+        console.warn(`[CustomModView] ${sourceBasename} too large to inspect`);
+        info = fallbackInspection("wad");
+      }
     }
 
-    const info = await inspectFile(innerName, innerBytes);
     if (info.isIwad) {
       throw new Error("This file is an IWAD (base game). Base games are managed in Settings, not added as custom mods.");
     }
@@ -519,14 +552,17 @@ async function onSubmit() {
         const st = await stat(sourcePath.value);
         actualSize = st.size;
       } catch {
-        actualSize = pickedZip.value?.innerBytes.length ?? 0;
+        actualSize = pickedZip.value?.size ?? 0;
       }
     } else if (pickedZip.value) {
       if (!sourceIsTarget && await exists(targetPath)) {
         throw new Error(`A file named "${sourceFilename}" already exists in the library. Rename it or remove it before importing.`);
       }
-      await writeFile(targetPath, pickedZip.value.innerBytes);
-      actualSize = pickedZip.value.innerBytes.length;
+      actualSize = await invoke<number>("extract_zip_entry", {
+        zipPath: sourcePath.value,
+        entryPath: pickedZip.value.entryPath,
+        destPath: targetPath,
+      });
     } else if (sourceIsTarget) {
       const st = await stat(targetPath);
       actualSize = st.size;

--- a/src/components/CustomModView.vue
+++ b/src/components/CustomModView.vue
@@ -8,13 +8,8 @@ import { useLibrary } from "../composables/useLibrary";
 import { useDownload } from "../composables/useDownload";
 import { useCustomWads } from "../composables/useCustomWads";
 import { useSettings } from "../composables/useSettings";
-import { inspectFile, inspectPk3FromArchive, fallbackInspection, parseInfoText, type FileInspection } from "../lib/wadInspect";
+import { inspectGameFile, parseInfoText, type FileInspection } from "../lib/wadInspect";
 import { findGameFileEntries, selectPrimaryGameFile, type ZipEntryInfo } from "../lib/zipExtract";
-
-// Largest file we'll read into memory to inspect. Bigger files still
-// import fine; they just skip the metadata pre-fill.
-const MAX_INSPECT_BYTES = 128 * 1024 * 1024;
-const MAX_SIDECAR_TXT_BYTES = 4 * 1024 * 1024;
 
 const props = defineProps<{
   defaultType: WadEntry["type"];
@@ -143,10 +138,10 @@ const errorMsg = ref<string>("");
 const submitting = ref(false);
 const inspection = ref<FileInspection | null>(null);
 const inspecting = ref(false);
-// When user picks a .zip bundle, we remember which entry inside it is the
-// game file so onSubmit can stream-extract it (vs. file-to-file copy used
-// for bare .wad/.pk3). innerName is the basename we'll save as.
-const pickedZip = ref<{ innerName: string; entryPath: string; size: number } | null>(null);
+// When user picks a .zip bundle, the inner game file is stream-extracted
+// to a temp file at pick time; inspection and the eventual copy into the
+// library both work from that file. innerName is the basename we'll save as.
+const pickedZip = ref<{ innerName: string; tempPath: string; size: number } | null>(null);
 
 const pickerOpen = ref(false);
 const pickerRef = ref<HTMLElement | null>(null);
@@ -304,28 +299,31 @@ async function pickFile() {
 
     // What we inspect (and ultimately copy into the library) depends on
     // whether the picked file is a raw .wad/.pk3 or a .zip bundle that
-    // contains one.
+    // contains one. For a .zip, the inner game file is stream-extracted to
+    // a temp file so the same on-disk inspection path covers all picks.
     let innerName = sourceBasename;
+    let innerPath = picked;
     let zipSidecarText = "";
-    let info: FileInspection;
 
     if (sourceExt === "zip") {
       const entries = await invoke<ZipEntryInfo[]>("list_zip_entries", { zipPath: picked });
       const gameFiles = findGameFileEntries(entries);  // throws if none
       const { primary } = selectPrimaryGameFile(gameFiles);
       innerName = primary.name;
-      pickedZip.value = { innerName, entryPath: primary.path, size: primary.size };
+      innerPath = await invoke<string>("extract_zip_entry_to_temp", {
+        zipPath: picked,
+        entryPath: primary.path,
+      });
+      pickedZip.value = { innerName, tempPath: innerPath, size: primary.size };
 
       // Read any .txt at the zip root (the idgames upload-template sidecar).
       // We scan all entries since "Beautiful Doom" style PK3s nest the .txt
       // inside a single folder.
       for (const entry of entries) {
         if (!entry.path.toLowerCase().endsWith(".txt")) continue;
-        if (entry.size > MAX_SIDECAR_TXT_BYTES) continue;
         const buf = await invoke<ArrayBuffer>("read_zip_entry", {
           zipPath: picked,
           entryPath: entry.path,
-          maxBytes: MAX_SIDECAR_TXT_BYTES,
         });
         const text = new TextDecoder().decode(new Uint8Array(buf));
         if (/^\s*Title\s*:/im.test(text) || /^\s*Authors?\s*:/im.test(text)) {
@@ -333,34 +331,9 @@ async function pickFile() {
           break;
         }
       }
-
-      if (primary.size <= MAX_INSPECT_BYTES) {
-        const buf = await invoke<ArrayBuffer>("read_zip_entry", {
-          zipPath: picked,
-          entryPath: primary.path,
-          maxBytes: MAX_INSPECT_BYTES,
-        });
-        info = await inspectFile(innerName, new Uint8Array(buf));
-      } else {
-        console.warn(`[CustomModView] ${innerName} too large to inspect (${primary.size} bytes)`);
-        info = fallbackInspection(innerName.toLowerCase().endsWith(".pk3") ? "pk3" : "wad");
-      }
-    } else if (sourceExt === "pk3") {
-      info = await inspectPk3FromArchive(picked);
-    } else {
-      try {
-        const buf = await invoke<ArrayBuffer>("read_file_for_inspection", {
-          sourcePath: picked,
-          maxBytes: MAX_INSPECT_BYTES,
-        });
-        info = await inspectFile(sourceBasename, new Uint8Array(buf));
-      } catch (e) {
-        if (!String(e).includes("too large to inspect")) throw e;
-        console.warn(`[CustomModView] ${sourceBasename} too large to inspect`);
-        info = fallbackInspection("wad");
-      }
     }
 
+    const info = await inspectGameFile(innerName, innerPath);
     if (info.isIwad) {
       throw new Error("This file is an IWAD (base game). Base games are managed in Settings, not added as custom mods.");
     }
@@ -558,10 +531,9 @@ async function onSubmit() {
       if (!sourceIsTarget && await exists(targetPath)) {
         throw new Error(`A file named "${sourceFilename}" already exists in the library. Rename it or remove it before importing.`);
       }
-      actualSize = await invoke<number>("extract_zip_entry", {
-        zipPath: sourcePath.value,
-        entryPath: pickedZip.value.entryPath,
-        destPath: targetPath,
+      actualSize = await invoke<number>("import_custom_wad", {
+        sourcePath: pickedZip.value.tempPath,
+        targetPath,
       });
     } else if (sourceIsTarget) {
       const st = await stat(targetPath);

--- a/src/components/DownloadPlayButton.vue
+++ b/src/components/DownloadPlayButton.vue
@@ -4,7 +4,7 @@ import type { WadEntry } from "../lib/schema";
 import { useDownload } from "../composables/useDownload";
 import { formatBytes } from "../lib/format";
 
-const { isDownloaded: checkDownloaded, isDownloading: checkDownloading, getDownloadProgress } = useDownload();
+const { isDownloaded: checkDownloaded, isDownloading: checkDownloading, isInstalling: checkInstalling, getDownloadProgress } = useDownload();
 
 const props = defineProps<{
   wad: WadEntry;
@@ -19,16 +19,19 @@ const props = defineProps<{
 const emit = defineEmits<{ play: [wad: WadEntry] }>();
 
 const isDownloaded = computed(() => props.wad.type === "iwad" || checkDownloaded(props.wad.slug));
-const isDownloading = computed(() => checkDownloading(props.wad.slug));
+const isInstalling = computed(() => checkInstalling(props.wad.slug));
+const isDownloading = computed(() => checkDownloading(props.wad.slug) || isInstalling.value);
 const downloadProgress = computed(() => getDownloadProgress(props.wad.slug));
 
 const progressPercent = computed(() => {
+  if (isInstalling.value) return 100;
   const dp = downloadProgress.value;
   if (!dp || dp.total === 0) return 0;
   return Math.round((dp.progress / dp.total) * 100);
 });
 
 const progressText = computed(() => {
+  if (isInstalling.value) return "Installing...";
   const dp = downloadProgress.value;
   if (!dp) return "Downloading...";
   if (dp.total === 0) return `${formatBytes(dp.progress)}`;
@@ -45,7 +48,7 @@ const progressText = computed(() => {
   >
     <!-- Progress bar background -->
     <div
-      v-if="isDownloading && downloadProgress"
+      v-if="isDownloading && (downloadProgress || isInstalling)"
       class="absolute inset-0 bg-blue-600 transition-all duration-300"
       :style="{ width: `${progressPercent}%` }"
     />

--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -1,11 +1,11 @@
 import { ref } from "vue";
-import { exists, mkdir, remove, readFile, rename, stat, writeFile } from "@tauri-apps/plugin-fs";
+import { exists, mkdir, remove, rename, stat } from "@tauri-apps/plugin-fs";
 import { download as tauriDownload } from "@tauri-apps/plugin-upload";
 import { invoke } from "@tauri-apps/api/core";
 import type { WadEntry } from "../lib/schema";
 import { type LauncherDownloads } from "../lib/schema";
 import { useLevelNames } from "./useLevelNames";
-import { findGameFilesInZip, selectPrimaryGameFile } from "../lib/zipExtract";
+import { selectPrimaryGameFile, type GameFileInfo } from "../lib/zipExtract";
 import { useLibrary } from "./useLibrary";
 
 // Progress info for a download
@@ -17,6 +17,7 @@ export interface DownloadProgress {
 // Singleton state
 const downloads = ref<LauncherDownloads>({ version: 1, downloads: {} });
 const downloading = ref<Set<string>>(new Set());
+const installing = ref<Set<string>>(new Set());
 const downloadProgress = ref<Record<string, DownloadProgress>>({});
 
 /**
@@ -24,27 +25,7 @@ const downloadProgress = ref<Record<string, DownloadProgress>>({});
  * Throws if file is corrupt or wrong format.
  */
 async function validateDownload(path: string, filename: string): Promise<void> {
-  const data = await readFile(path);
-  const bytes = new Uint8Array(data);
-  const ext = filename.toLowerCase().split(".").pop();
-
-  if (ext === "zip" || ext === "pk3") {
-    // ZIP files start with PK (0x50 0x4B)
-    if (bytes.length < 2 || bytes[0] !== 0x50 || bytes[1] !== 0x4b) {
-      throw new Error(
-        `Invalid ZIP file: ${filename} - file appears corrupted or is not a ZIP archive (got ${bytes.length} bytes, magic: ${bytes[0]?.toString(16)} ${bytes[1]?.toString(16)})`
-      );
-    }
-  } else if (ext === "wad") {
-    // WAD files start with IWAD or PWAD
-    if (bytes.length < 4) {
-      throw new Error(`Invalid WAD file: ${filename} - file too small (${bytes.length} bytes)`);
-    }
-    const magic = String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
-    if (magic !== "IWAD" && magic !== "PWAD") {
-      throw new Error(`Invalid WAD file: ${filename} - expected IWAD/PWAD header, got "${magic}"`);
-    }
-  }
+  await invoke("validate_game_file", { path, filename });
 }
 
 export function useDownload() {
@@ -52,27 +33,30 @@ export function useDownload() {
   const { base, wadFile } = useLibrary();
 
   /**
-   * Extract game files (.wad/.pk3) from a ZIP archive and write them to disk.
-   * Returns the primary wadFilename and any additional file paths.
+   * Extract game files (.wad/.pk3) from a ZIP archive into the library.
+   * Returns the primary wadFilename and any additional file names.
    */
   async function extractAndWriteGameFiles(
+    slug: string,
     zipPath: string
   ): Promise<{ wadFilename: string; additionalFiles: string[] }> {
-    const zipData = await readFile(zipPath);
-    const gameFiles = findGameFilesInZip(new Uint8Array(zipData));
-    const { primary, additional } = selectPrimaryGameFile(gameFiles);
+    installing.value.add(slug);
+    try {
+      const extracted = await invoke<GameFileInfo[]>("extract_game_files", {
+        zipPath,
+        destDir: base(),
+      });
+      const { primary, additional } = selectPrimaryGameFile(extracted);
 
-    await writeFile(wadFile(primary.name), primary.data);
-    console.log(`[extract] Extracted primary: ${primary.name} (${primary.data.length} bytes)`);
+      console.log(`[extract] Extracted primary: ${primary.name} (${primary.size} bytes)`);
+      for (const file of additional) {
+        console.log(`[extract] Extracted additional: ${file.name} (${file.size} bytes)`);
+      }
 
-    const additionalFiles: string[] = [];
-    for (const file of additional) {
-      await writeFile(wadFile(file.name), file.data);
-      additionalFiles.push(file.name);
-      console.log(`[extract] Extracted additional: ${file.name} (${file.data.length} bytes)`);
+      return { wadFilename: primary.name, additionalFiles: additional.map(f => f.name) };
+    } finally {
+      installing.value.delete(slug);
     }
-
-    return { wadFilename: primary.name, additionalFiles };
   }
 
   async function loadState() {
@@ -89,6 +73,10 @@ export function useDownload() {
 
   function isDownloading(slug: string): boolean {
     return downloading.value.has(slug);
+  }
+
+  function isInstalling(slug: string): boolean {
+    return installing.value.has(slug);
   }
 
   function getDownloadProgress(slug: string): DownloadProgress | undefined {
@@ -118,14 +106,14 @@ export function useDownload() {
       }
 
       if (info.wadFilename && info.filename.endsWith('.zip') && await exists(wadFile(info.filename))) {
-        const { wadFilename } = await extractAndWriteGameFiles(wadFile(info.filename));
+        const { wadFilename } = await extractAndWriteGameFiles(wad.slug, wadFile(info.filename));
         info.wadFilename = wadFilename;
         await saveState();
         return wadFile(wadFilename);
       }
 
       if (info.filename.endsWith('.zip') && !info.wadFilename && await exists(wadFile(info.filename))) {
-        const { wadFilename } = await extractAndWriteGameFiles(wadFile(info.filename));
+        const { wadFilename } = await extractAndWriteGameFiles(wad.slug, wadFile(info.filename));
         info.wadFilename = wadFilename;
         await saveState();
         return wadFile(wadFilename);
@@ -186,7 +174,7 @@ export function useDownload() {
       const isZip = filename.toLowerCase().endsWith('.zip');
 
       if (isZip) {
-        const { wadFilename } = await extractAndWriteGameFiles(path);
+        const { wadFilename } = await extractAndWriteGameFiles(wad.slug, path);
         downloads.value.downloads[wad.slug] = {
           filename, wadFilename, downloadedAt: new Date().toISOString(), size: fileStat.size, externalPath: "",
         };
@@ -270,6 +258,7 @@ export function useDownload() {
     loadState,
     isDownloaded,
     isDownloading,
+    isInstalling,
     getDownloadProgress,
     getDownloadInfo,
     downloadProgress,

--- a/src/composables/useLevelNames.ts
+++ b/src/composables/useLevelNames.ts
@@ -7,11 +7,6 @@ import { useLibrary } from "./useLibrary";
 import type { LauncherDownloads } from "../lib/schema";
 import type { ZipEntryInfo } from "../lib/zipExtract";
 
-// Caps for reading archive entries into the webview; larger entries are
-// skipped (missing level names beats a multi-GB webview process).
-const MAX_WAD_ENTRY_BYTES = 128 * 1024 * 1024;
-const MAX_MAPINFO_BYTES = 8 * 1024 * 1024;
-
 // Singleton cache: slug -> (mapId -> levelName)
 const levelNamesCache = ref<Map<string, Map<string, string>>>(new Map());
 
@@ -105,11 +100,10 @@ export function useLevelNames() {
         try {
           const entries = await invoke<ZipEntryInfo[]>("list_zip_entries", { zipPath: filePath });
 
-          const readEntry = async (entryPath: string, maxBytes: number): Promise<Uint8Array> => {
+          const readEntry = async (entryPath: string): Promise<Uint8Array> => {
             const buf = await invoke<ArrayBuffer>("read_zip_entry", {
               zipPath: filePath,
               entryPath,
-              maxBytes,
             });
             return new Uint8Array(buf);
           };
@@ -117,12 +111,8 @@ export function useLevelNames() {
           // Find WAD files inside the ZIP
           for (const entry of entries) {
             if (!entry.path.toLowerCase().endsWith(".wad")) continue;
-            if (entry.size > MAX_WAD_ENTRY_BYTES) {
-              console.warn(`[LevelNames] Skipping ${entry.path}: ${entry.size} bytes exceeds cap`);
-              continue;
-            }
             try {
-              const levels = extractLevelNamesFromData(await readEntry(entry.path, MAX_WAD_ENTRY_BYTES));
+              const levels = extractLevelNamesFromData(await readEntry(entry.path));
               for (const [mapId, levelName] of levels) {
                 if (!allLevels.has(mapId)) {
                   allLevels.set(mapId, levelName);
@@ -138,9 +128,8 @@ export function useLevelNames() {
           for (const entry of entries) {
             const baseName = entry.path.split("/").pop()?.toUpperCase() || "";
             if (!mapinfoLumps.includes(baseName)) continue;
-            if (entry.size > MAX_MAPINFO_BYTES) continue;
             try {
-              const content = new TextDecoder().decode(await readEntry(entry.path, MAX_MAPINFO_BYTES));
+              const content = new TextDecoder().decode(await readEntry(entry.path));
               const levels = parseLevelNamesFromContent(baseName, content);
               for (const [mapId, levelName] of levels) {
                 if (!allLevels.has(mapId)) {

--- a/src/composables/useLevelNames.ts
+++ b/src/composables/useLevelNames.ts
@@ -1,11 +1,16 @@
 import { ref } from "vue";
-import { readFile, readTextFile, writeTextFile, exists, mkdir } from "@tauri-apps/plugin-fs";
-import { unzipSync, strFromU8 } from "fflate";
+import { readTextFile, writeTextFile, exists, mkdir } from "@tauri-apps/plugin-fs";
 import { extractLevelNames, extractLevelNamesFromData, parseLevelNamesFromContent } from "../lib/wadParser";
 import { invoke } from "@tauri-apps/api/core";
 import { isNotFoundError } from "../lib/errors";
 import { useLibrary } from "./useLibrary";
 import type { LauncherDownloads } from "../lib/schema";
+import type { ZipEntryInfo } from "../lib/zipExtract";
+
+// Caps for reading archive entries into the webview; larger entries are
+// skipped (missing level names beats a multi-GB webview process).
+const MAX_WAD_ENTRY_BYTES = 128 * 1024 * 1024;
+const MAX_MAPINFO_BYTES = 8 * 1024 * 1024;
 
 // Singleton cache: slug -> (mapId -> levelName)
 const levelNamesCache = ref<Map<string, Map<string, string>>>(new Map());
@@ -95,49 +100,59 @@ export function useLevelNames() {
       let allLevels = new Map<string, string>();
 
       if (filename.endsWith(".zip") || filename.endsWith(".pk3")) {
-        // Handle ZIP archives (including .pk3 which are also ZIP format)
-        const data = await readFile(filePath);
-        const uint8 = new Uint8Array(data);
-
+        // Handle ZIP archives (including .pk3 which are also ZIP format).
+        // Work from the entry listing and fetch only the entries we parse.
         try {
-          const unzipped = unzipSync(uint8);
+          const entries = await invoke<ZipEntryInfo[]>("list_zip_entries", { zipPath: filePath });
+
+          const readEntry = async (entryPath: string, maxBytes: number): Promise<Uint8Array> => {
+            const buf = await invoke<ArrayBuffer>("read_zip_entry", {
+              zipPath: filePath,
+              entryPath,
+              maxBytes,
+            });
+            return new Uint8Array(buf);
+          };
 
           // Find WAD files inside the ZIP
-          for (const [entryName, entryData] of Object.entries(unzipped)) {
-            if (entryName.toLowerCase().endsWith(".wad")) {
-              try {
-                const levels = extractLevelNamesFromData(entryData);
-                for (const [mapId, levelName] of levels) {
-                  if (!allLevels.has(mapId)) {
-                    allLevels.set(mapId, levelName);
-                  }
+          for (const entry of entries) {
+            if (!entry.path.toLowerCase().endsWith(".wad")) continue;
+            if (entry.size > MAX_WAD_ENTRY_BYTES) {
+              console.warn(`[LevelNames] Skipping ${entry.path}: ${entry.size} bytes exceeds cap`);
+              continue;
+            }
+            try {
+              const levels = extractLevelNamesFromData(await readEntry(entry.path, MAX_WAD_ENTRY_BYTES));
+              for (const [mapId, levelName] of levels) {
+                if (!allLevels.has(mapId)) {
+                  allLevels.set(mapId, levelName);
                 }
-              } catch (e) {
-                console.warn(`Failed to parse ${entryName}:`, e);
               }
+            } catch (e) {
+              console.warn(`Failed to parse ${entry.path}:`, e);
             }
           }
 
           // Also check for MAPINFO files directly in the ZIP (for .pk3)
           const mapinfoLumps = ["MAPINFO", "ZMAPINFO", "EMAPINFO", "UMAPINFO"];
-          for (const [entryName, entryData] of Object.entries(unzipped)) {
-            const baseName = entryName.split("/").pop()?.toUpperCase() || "";
-            if (mapinfoLumps.includes(baseName)) {
-              try {
-                const content = strFromU8(entryData);
-                const levels = parseLevelNamesFromContent(baseName, content);
-                for (const [mapId, levelName] of levels) {
-                  if (!allLevels.has(mapId)) {
-                    allLevels.set(mapId, levelName);
-                  }
+          for (const entry of entries) {
+            const baseName = entry.path.split("/").pop()?.toUpperCase() || "";
+            if (!mapinfoLumps.includes(baseName)) continue;
+            if (entry.size > MAX_MAPINFO_BYTES) continue;
+            try {
+              const content = new TextDecoder().decode(await readEntry(entry.path, MAX_MAPINFO_BYTES));
+              const levels = parseLevelNamesFromContent(baseName, content);
+              for (const [mapId, levelName] of levels) {
+                if (!allLevels.has(mapId)) {
+                  allLevels.set(mapId, levelName);
                 }
-              } catch (e) {
-                console.warn(`Failed to parse ${entryName}:`, e);
               }
+            } catch (e) {
+              console.warn(`Failed to parse ${entry.path}:`, e);
             }
           }
         } catch (e) {
-          console.warn(`Failed to unzip ${filename}:`, e);
+          console.warn(`Failed to scan ${filename}:`, e);
         }
       } else if (filename.endsWith(".wad")) {
         // Direct WAD file

--- a/src/lib/wadInspect.ts
+++ b/src/lib/wadInspect.ts
@@ -30,7 +30,6 @@
 //     extraction date, etc.) to use as a year signal.
 //
 // Everything below is the minimum that earns its keep on the audit corpus.
-import { unzipSync } from "fflate";
 import { invoke } from "@tauri-apps/api/core";
 import type { Iwad, WadEntry } from "./schema";
 
@@ -38,10 +37,9 @@ function decodeText(data: Uint8Array): string {
   return new TextDecoder("utf-8", { fatal: false }).decode(data);
 }
 
-// Caps for reading archive entries during inspection; larger entries are
-// skipped and inspection degrades gracefully.
-const MAX_TEXT_ENTRY_BYTES = 4 * 1024 * 1024;
-const MAX_IMAGE_ENTRY_BYTES = 32 * 1024 * 1024;
+async function readRange(path: string, offset: number, len: number): Promise<Uint8Array> {
+  return new Uint8Array(await invoke<ArrayBuffer>("read_file_range", { path, offset, len }));
+}
 
 export interface FileInspection {
   format: "wad" | "pk3";
@@ -189,31 +187,39 @@ const TXT_DATE_RE = /^\s*(?:Release\s*date|Date)\s*:\s*(.+?)\s*$/im;
 
 const MAPINFO_MAP_NAME_RE = /^\s*map\s+\S+\s+"([^"]+)"/im;
 
-export async function inspectFile(filename: string, data: Uint8Array): Promise<FileInspection> {
+/**
+ * Inspect a .wad or .pk3 on disk. Reads only what it parses — WAD header,
+ * directory and selected lumps via byte ranges; pk3 entries via the zip
+ * listing — so file size is irrelevant.
+ */
+export async function inspectGameFile(filename: string, path: string): Promise<FileInspection> {
   const ext = filename.toLowerCase().split(".").pop() ?? "";
-  if (ext === "wad") return inspectWad(data);
-  if (ext === "pk3") return inspectPk3(data);
+  if (ext === "wad") return inspectWadFromFile(path);
+  if (ext === "pk3") return inspectPk3FromArchive(path);
   throw new Error(`Unsupported extension: .${ext}`);
 }
 
-async function inspectWad(data: Uint8Array): Promise<FileInspection> {
-  if (data.length < 12) throw new Error("WAD file too small");
-  const magic = String.fromCharCode(data[0], data[1], data[2], data[3]);
+async function inspectWadFromFile(path: string): Promise<FileInspection> {
+  const header = await readRange(path, 0, 12);
+  const magic = String.fromCharCode(header[0], header[1], header[2], header[3]);
   if (magic !== "IWAD" && magic !== "PWAD") {
     throw new Error(`Not a WAD file (magic: ${magic})`);
   }
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  const numLumps = view.getInt32(4, true);
-  const dirOffset = view.getInt32(8, true);
+  const headerView = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  const numLumps = headerView.getInt32(4, true);
+  const dirOffset = headerView.getInt32(8, true);
+  if (numLumps < 0) throw new Error(`Invalid WAD: negative lump count (${numLumps})`);
 
+  const dir = await readRange(path, dirOffset, numLumps * 16);
+  const view = new DataView(dir.buffer, dir.byteOffset, dir.byteLength);
   const lumps: { name: string; offset: number; size: number }[] = [];
   for (let i = 0; i < numLumps; i++) {
-    const entry = dirOffset + i * 16;
+    const entry = i * 16;
     const offset = view.getInt32(entry, true);
     const size = view.getInt32(entry + 4, true);
     let name = "";
     for (let j = 0; j < 8; j++) {
-      const c = data[entry + 8 + j];
+      const c = dir[entry + 8 + j];
       if (c === 0) break;
       name += String.fromCharCode(c);
     }
@@ -231,9 +237,7 @@ async function inspectWad(data: Uint8Array): Promise<FileInspection> {
 
   const mapInfoLump = lumps.find(l => l.name === "ZMAPINFO" || l.name === "MAPINFO");
   if (mapInfoLump) {
-    const text = new TextDecoder("utf-8", { fatal: false }).decode(
-      data.subarray(mapInfoLump.offset, mapInfoLump.offset + mapInfoLump.size)
-    );
+    const text = decodeText(await readRange(path, mapInfoLump.offset, mapInfoLump.size));
     const m = text.match(MAPINFO_MAP_NAME_RE);
     if (m) firstMapTitle = m[1];
   }
@@ -244,7 +248,7 @@ async function inspectWad(data: Uint8Array): Promise<FileInspection> {
   for (const lumpName of ["TITLEPIC", "INTERPIC"]) {
     const lump = lumps.find(l => l.name === lumpName);
     if (lump) {
-      const bytes = data.subarray(lump.offset, lump.offset + lump.size);
+      const bytes = await readRange(path, lump.offset, lump.size);
       try {
         titlepic = await imageBytesToPng(bytes);
         if (titlepic) break;
@@ -269,11 +273,10 @@ async function inspectWad(data: Uint8Array): Promise<FileInspection> {
   };
 }
 
-// One pk3 entry the inspector can lazily pull — backed by an in-memory
-// unzip or by the Rust `read_zip_entry` command.
+// One pk3 entry the inspector can lazily pull via the Rust `read_zip_entry`
+// command.
 interface Pk3EntryRef {
   path: string;
-  size: number;
   read: () => Promise<Uint8Array>;
 }
 
@@ -284,25 +287,13 @@ export async function inspectPk3FromArchive(archivePath: string): Promise<FileIn
   });
   const refs: Pk3EntryRef[] = entries.map(e => ({
     path: e.path,
-    size: e.size,
     read: async () =>
       new Uint8Array(
         await invoke<ArrayBuffer>("read_zip_entry", {
           zipPath: archivePath,
           entryPath: e.path,
-          maxBytes: e.size,
         })
       ),
-  }));
-  return inspectPk3Entries(refs);
-}
-
-async function inspectPk3(data: Uint8Array): Promise<FileInspection> {
-  const entries = unzipSync(data);
-  const refs: Pk3EntryRef[] = Object.entries(entries).map(([path, payload]) => ({
-    path,
-    size: payload.length,
-    read: async () => payload,
   }));
   return inspectPk3Entries(refs);
 }
@@ -334,7 +325,7 @@ async function inspectPk3Entries(refs: Pk3EntryRef[]): Promise<FileInspection> {
     return base === "mapinfo" || base === "zmapinfo" ||
       base.startsWith("mapinfo.") || base.startsWith("zmapinfo.");
   });
-  if (mapInfoEntry && mapInfoEntry.size <= MAX_TEXT_ENTRY_BYTES) {
+  if (mapInfoEntry) {
     const text = decodeText(await mapInfoEntry.read());
     const m = text.match(MAPINFO_MAP_NAME_RE);
     if (m) firstMapTitle = m[1];
@@ -349,7 +340,6 @@ async function inspectPk3Entries(refs: Pk3EntryRef[]): Promise<FileInspection> {
     if (depth > 1) continue;
     const base = ref.path.toLowerCase().split("/").pop() ?? "";
     if (!/\.(txt|md|nfo)$/i.test(base)) continue;
-    if (ref.size > MAX_TEXT_ENTRY_BYTES) continue;
     const text = decodeText(await ref.read());
     const parsed = parseInfoText(text);
     if (!author && parsed.author) author = parsed.author;
@@ -368,7 +358,7 @@ async function inspectPk3Entries(refs: Pk3EntryRef[]): Promise<FileInspection> {
       const stem = base.replace(/\.[^.]+$/, "");
       return stem === candidate;
     });
-    if (entry && entry.size <= MAX_IMAGE_ENTRY_BYTES) {
+    if (entry) {
       try {
         titlepic = await imageBytesToPng(await entry.read());
         if (titlepic) break;
@@ -414,26 +404,6 @@ export function parseInfoText(text: string): { title: string; author: string; ye
     title: titleMatch ? titleMatch[1].trim() : "",
     author: authorMatch ? authorMatch[1].trim() : "",
     year,
-  };
-}
-
-/**
- * Minimal inspection for files too large to read into the webview.
- * Import still works; the user just fills in metadata by hand.
- */
-export function fallbackInspection(format: "wad" | "pk3"): FileInspection {
-  return {
-    format,
-    isIwad: false,
-    mapCount: 0,
-    mapNames: [],
-    firstMapTitle: "",
-    author: "",
-    year: 0,
-    hasGameplayCode: false,
-    suggestedType: format === "pk3" ? "gameplay-mod" : "megawad",
-    suggestedIwad: "doom2",
-    titlepic: null,
   };
 }
 

--- a/src/lib/wadInspect.ts
+++ b/src/lib/wadInspect.ts
@@ -30,8 +30,18 @@
 //     extraction date, etc.) to use as a year signal.
 //
 // Everything below is the minimum that earns its keep on the audit corpus.
-import { unzipSync, strFromU8 } from "fflate";
+import { unzipSync } from "fflate";
+import { invoke } from "@tauri-apps/api/core";
 import type { Iwad, WadEntry } from "./schema";
+
+function decodeText(data: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: false }).decode(data);
+}
+
+// Caps for reading archive entries during inspection; larger entries are
+// skipped and inspection degrades gracefully.
+const MAX_TEXT_ENTRY_BYTES = 4 * 1024 * 1024;
+const MAX_IMAGE_ENTRY_BYTES = 32 * 1024 * 1024;
 
 export interface FileInspection {
   format: "wad" | "pk3";
@@ -259,9 +269,46 @@ async function inspectWad(data: Uint8Array): Promise<FileInspection> {
   };
 }
 
+// One pk3 entry the inspector can lazily pull — backed by an in-memory
+// unzip or by the Rust `read_zip_entry` command.
+interface Pk3EntryRef {
+  path: string;
+  size: number;
+  read: () => Promise<Uint8Array>;
+}
+
+/** Inspect a .pk3 on disk from its zip-entry listing. */
+export async function inspectPk3FromArchive(archivePath: string): Promise<FileInspection> {
+  const entries = await invoke<{ path: string; size: number }[]>("list_zip_entries", {
+    zipPath: archivePath,
+  });
+  const refs: Pk3EntryRef[] = entries.map(e => ({
+    path: e.path,
+    size: e.size,
+    read: async () =>
+      new Uint8Array(
+        await invoke<ArrayBuffer>("read_zip_entry", {
+          zipPath: archivePath,
+          entryPath: e.path,
+          maxBytes: e.size,
+        })
+      ),
+  }));
+  return inspectPk3Entries(refs);
+}
+
 async function inspectPk3(data: Uint8Array): Promise<FileInspection> {
   const entries = unzipSync(data);
-  const paths = Object.keys(entries);
+  const refs: Pk3EntryRef[] = Object.entries(entries).map(([path, payload]) => ({
+    path,
+    size: payload.length,
+    read: async () => payload,
+  }));
+  return inspectPk3Entries(refs);
+}
+
+async function inspectPk3Entries(refs: Pk3EntryRef[]): Promise<FileInspection> {
+  const paths = refs.map(r => r.path);
 
   const mapNamesSet = new Set<string>();
   for (const p of paths) {
@@ -282,13 +329,13 @@ async function inspectPk3(data: Uint8Array): Promise<FileInspection> {
   let year = 0;
 
   // MAPINFO/ZMAPINFO — used only for the human-readable map name.
-  const mapInfoEntry = Object.entries(entries).find(([p]) => {
-    const base = (p.toLowerCase().split("/").pop() ?? "");
+  const mapInfoEntry = refs.find(r => {
+    const base = (r.path.toLowerCase().split("/").pop() ?? "");
     return base === "mapinfo" || base === "zmapinfo" ||
       base.startsWith("mapinfo.") || base.startsWith("zmapinfo.");
   });
-  if (mapInfoEntry) {
-    const text = strFromU8(mapInfoEntry[1]);
+  if (mapInfoEntry && mapInfoEntry.size <= MAX_TEXT_ENTRY_BYTES) {
+    const text = decodeText(await mapInfoEntry.read());
     const m = text.match(MAPINFO_MAP_NAME_RE);
     if (m) firstMapTitle = m[1];
   }
@@ -297,12 +344,13 @@ async function inspectPk3(data: Uint8Array): Promise<FileInspection> {
   // These reliably carry Title/Authors/Release-date when present (Beautiful
   // Doom, game_support.pk3, etc.). Scan them in order and take first hit per
   // field.
-  for (const [path, payload] of Object.entries(entries)) {
-    const depth = path.split("/").length - 1;
+  for (const ref of refs) {
+    const depth = ref.path.split("/").length - 1;
     if (depth > 1) continue;
-    const base = path.toLowerCase().split("/").pop() ?? "";
+    const base = ref.path.toLowerCase().split("/").pop() ?? "";
     if (!/\.(txt|md|nfo)$/i.test(base)) continue;
-    const text = strFromU8(payload);
+    if (ref.size > MAX_TEXT_ENTRY_BYTES) continue;
+    const text = decodeText(await ref.read());
     const parsed = parseInfoText(text);
     if (!author && parsed.author) author = parsed.author;
     if (!year && parsed.year) year = parsed.year;
@@ -315,14 +363,14 @@ async function inspectPk3(data: Uint8Array): Promise<FileInspection> {
   let titlepic: Titlepic | null = null;
   const candidatePaths = ["TITLEPIC", "INTERPIC"];
   for (const candidate of candidatePaths) {
-    const entry = Object.entries(entries).find(([p]) => {
-      const base = (p.split("/").pop() ?? "").toUpperCase();
+    const entry = refs.find(r => {
+      const base = (r.path.split("/").pop() ?? "").toUpperCase();
       const stem = base.replace(/\.[^.]+$/, "");
       return stem === candidate;
     });
-    if (entry) {
+    if (entry && entry.size <= MAX_IMAGE_ENTRY_BYTES) {
       try {
-        titlepic = await imageBytesToPng(entry[1]);
+        titlepic = await imageBytesToPng(await entry.read());
         if (titlepic) break;
       } catch (e) {
         console.warn(`[wadInspect] ${candidate} decode failed:`, e);
@@ -366,6 +414,26 @@ export function parseInfoText(text: string): { title: string; author: string; ye
     title: titleMatch ? titleMatch[1].trim() : "",
     author: authorMatch ? authorMatch[1].trim() : "",
     year,
+  };
+}
+
+/**
+ * Minimal inspection for files too large to read into the webview.
+ * Import still works; the user just fills in metadata by hand.
+ */
+export function fallbackInspection(format: "wad" | "pk3"): FileInspection {
+  return {
+    format,
+    isIwad: false,
+    mapCount: 0,
+    mapNames: [],
+    firstMapTitle: "",
+    author: "",
+    year: 0,
+    hasGameplayCode: false,
+    suggestedType: format === "pk3" ? "gameplay-mod" : "megawad",
+    suggestedIwad: "doom2",
+    titlepic: null,
   };
 }
 

--- a/src/lib/zipExtract.test.ts
+++ b/src/lib/zipExtract.test.ts
@@ -1,92 +1,71 @@
 import { describe, it, expect } from "vitest";
-import { zipSync } from "fflate";
-import { findGameFilesInZip, selectPrimaryGameFile, type GameFile } from "./zipExtract";
+import { findGameFileEntries, selectPrimaryGameFile, type ZipEntryInfo, type GameFileInfo } from "./zipExtract";
 
-/** Helper: create a synthetic ZIP containing given files */
-function makeZip(files: Record<string, Uint8Array>): Uint8Array {
-  return zipSync(files);
+/** Helper: build a zip listing like the `list_zip_entries` command returns */
+function listing(files: Record<string, number>): ZipEntryInfo[] {
+  return Object.entries(files).map(([path, size]) => ({ path, size }));
 }
 
-/** Helper: create dummy data of a given size */
-function dummyData(size: number): Uint8Array {
-  return new Uint8Array(size).fill(0x42);
-}
-
-describe("findGameFilesInZip", () => {
-  it("extracts single .wad from ZIP", () => {
-    const zip = makeZip({ "map01.wad": dummyData(100) });
-    const files = findGameFilesInZip(zip);
+describe("findGameFileEntries", () => {
+  it("finds single .wad in listing", () => {
+    const files = findGameFileEntries(listing({ "map01.wad": 100 }));
     expect(files).toHaveLength(1);
     expect(files[0].name).toBe("map01.wad");
-    expect(files[0].data.length).toBe(100);
+    expect(files[0].size).toBe(100);
   });
 
-  it("extracts single .pk3 from ZIP", () => {
-    const zip = makeZip({ "mod.pk3": dummyData(200) });
-    const files = findGameFilesInZip(zip);
+  it("finds single .pk3 in listing", () => {
+    const files = findGameFileEntries(listing({ "mod.pk3": 200 }));
     expect(files).toHaveLength(1);
     expect(files[0].name).toBe("mod.pk3");
   });
 
-  it("extracts multiple .wad files", () => {
-    const zip = makeZip({
-      "map01.wad": dummyData(100),
-      "map02.wad": dummyData(200),
-      "readme.txt": dummyData(50),
-    });
-    const files = findGameFilesInZip(zip);
+  it("finds multiple .wad files", () => {
+    const files = findGameFileEntries(
+      listing({ "map01.wad": 100, "map02.wad": 200, "readme.txt": 50 })
+    );
     expect(files).toHaveLength(2);
     const names = files.map(f => f.name).sort();
     expect(names).toEqual(["map01.wad", "map02.wad"]);
   });
 
   it("ignores non-game files (.txt, .deh, .bex)", () => {
-    const zip = makeZip({
-      "readme.txt": dummyData(50),
-      "patch.deh": dummyData(80),
-      "compat.bex": dummyData(30),
-      "level.wad": dummyData(100),
-    });
-    const files = findGameFilesInZip(zip);
+    const files = findGameFileEntries(
+      listing({ "readme.txt": 50, "patch.deh": 80, "compat.bex": 30, "level.wad": 100 })
+    );
     expect(files).toHaveLength(1);
     expect(files[0].name).toBe("level.wad");
   });
 
-  it("handles files in subdirectories (uses basename)", () => {
-    const zip = makeZip({
-      "mymod/maps/level.wad": dummyData(100),
-      "mymod/readme.txt": dummyData(50),
-    });
-    const files = findGameFilesInZip(zip);
+  it("handles files in subdirectories (uses basename, keeps entry path)", () => {
+    const files = findGameFileEntries(
+      listing({ "mymod/maps/level.wad": 100, "mymod/readme.txt": 50 })
+    );
     expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("level.wad");
+    expect(files[0].path).toBe("mymod/maps/level.wad");
+  });
+
+  it("handles backslash-separated paths from Windows-built zips", () => {
+    const files = findGameFileEntries(listing({ "mymod\\level.wad": 100 }));
     expect(files[0].name).toBe("level.wad");
   });
 
-  it("case-insensitive matching (.WAD, .Wad)", () => {
-    const zip = makeZip({
-      "LEVEL.WAD": dummyData(100),
-      "Mod.Pk3": dummyData(200),
-    });
-    const files = findGameFilesInZip(zip);
+  it("case-insensitive matching (.WAD, .Pk3)", () => {
+    const files = findGameFileEntries(listing({ "LEVEL.WAD": 100, "Mod.Pk3": 200 }));
     expect(files).toHaveLength(2);
     const names = files.map(f => f.name).sort();
     expect(names).toEqual(["LEVEL.WAD", "Mod.Pk3"]);
   });
 
-  it("throws when ZIP contains no game files", () => {
-    const zip = makeZip({
-      "readme.txt": dummyData(50),
-      "screenshot.png": dummyData(1000),
-    });
-    expect(() => findGameFilesInZip(zip)).toThrow("No WAD or PK3 files found inside ZIP archive");
+  it("throws when listing contains no game files", () => {
+    expect(() =>
+      findGameFileEntries(listing({ "readme.txt": 50, "screenshot.png": 1000 }))
+    ).toThrow("No WAD or PK3 files found inside ZIP archive");
   });
 
   it("handles mixed .wad and .pk3 files", () => {
-    const zip = makeZip({
-      "level.wad": dummyData(100),
-      "textures.pk3": dummyData(300),
-    });
-    const files = findGameFilesInZip(zip);
+    const files = findGameFileEntries(listing({ "level.wad": 100, "textures.pk3": 300 }));
     expect(files).toHaveLength(2);
     const names = files.map(f => f.name).sort();
     expect(names).toEqual(["level.wad", "textures.pk3"]);
@@ -95,17 +74,17 @@ describe("findGameFilesInZip", () => {
 
 describe("selectPrimaryGameFile", () => {
   it("single file: returns it as primary", () => {
-    const files: GameFile[] = [{ name: "level.wad", data: dummyData(100) }];
+    const files: GameFileInfo[] = [{ name: "level.wad", size: 100 }];
     const result = selectPrimaryGameFile(files);
     expect(result.primary.name).toBe("level.wad");
     expect(result.additional).toHaveLength(0);
   });
 
   it("multiple files: largest is primary", () => {
-    const files: GameFile[] = [
-      { name: "small.wad", data: dummyData(100) },
-      { name: "big.wad", data: dummyData(500) },
-      { name: "medium.wad", data: dummyData(300) },
+    const files: GameFileInfo[] = [
+      { name: "small.wad", size: 100 },
+      { name: "big.wad", size: 500 },
+      { name: "medium.wad", size: 300 },
     ];
     const result = selectPrimaryGameFile(files);
     expect(result.primary.name).toBe("big.wad");
@@ -113,10 +92,10 @@ describe("selectPrimaryGameFile", () => {
   });
 
   it("additional files sorted by name for determinism", () => {
-    const files: GameFile[] = [
-      { name: "zebra.wad", data: dummyData(100) },
-      { name: "main.wad", data: dummyData(500) },
-      { name: "alpha.wad", data: dummyData(100) },
+    const files: GameFileInfo[] = [
+      { name: "zebra.wad", size: 100 },
+      { name: "main.wad", size: 500 },
+      { name: "alpha.wad", size: 100 },
     ];
     const result = selectPrimaryGameFile(files);
     expect(result.primary.name).toBe("main.wad");

--- a/src/lib/zipExtract.ts
+++ b/src/lib/zipExtract.ts
@@ -1,27 +1,37 @@
-import { unzipSync } from "fflate";
+// Pure helpers for zip entry listings. Listing and extraction happen in
+// the Rust commands of src-tauri/src/game_archives.rs.
 
-export interface GameFile {
+/** One entry of a zip listing, as returned by the `list_zip_entries` command. */
+export interface ZipEntryInfo {
+  path: string;
+  size: number;
+}
+
+/** A .wad/.pk3 found in a listing: entry path + display basename. */
+export interface GameFileEntry extends ZipEntryInfo {
   name: string;
-  data: Uint8Array;
+}
+
+/** Anything with a name and size — enough to pick the primary file. */
+export interface GameFileInfo {
+  name: string;
+  size: number;
 }
 
 /**
- * Find all .wad and .pk3 files inside a ZIP archive.
+ * Find all .wad and .pk3 entries in a zip listing.
  * Strips directory paths and uses basename only.
  * Throws if no game files are found.
  */
-export function findGameFilesInZip(zipData: Uint8Array): GameFile[] {
-  const entries = unzipSync(zipData);
+export function findGameFileEntries(entries: ZipEntryInfo[]): GameFileEntry[] {
+  const gameFiles: GameFileEntry[] = [];
 
-  const gameFiles: GameFile[] = [];
-
-  for (const [path, data] of Object.entries(entries)) {
-    const lowerPath = path.toLowerCase();
+  for (const entry of entries) {
+    const lowerPath = entry.path.toLowerCase();
     if (lowerPath.endsWith(".wad") || lowerPath.endsWith(".pk3")) {
-      // Use basename only (strip directory paths)
-      const basename = path.split("/").pop() ?? path;
+      const basename = entry.path.split(/[/\\]/).pop() ?? entry.path;
       if (basename) {
-        gameFiles.push({ name: basename, data });
+        gameFiles.push({ ...entry, name: basename });
       }
     }
   }
@@ -36,18 +46,18 @@ export function findGameFilesInZip(zipData: Uint8Array): GameFile[] {
 /**
  * Select which file is primary (for -file) vs additional.
  * If one file: it's the primary.
- * If multiple: largest by data.length is primary, rest are additional (sorted by name).
+ * If multiple: largest by size is primary, rest are additional (sorted by name).
  */
-export function selectPrimaryGameFile(files: GameFile[]): {
-  primary: GameFile;
-  additional: GameFile[];
+export function selectPrimaryGameFile<T extends GameFileInfo>(files: T[]): {
+  primary: T;
+  additional: T[];
 } {
   if (files.length === 1) {
     return { primary: files[0], additional: [] };
   }
 
   // Sort by size descending to find largest
-  const sorted = [...files].sort((a, b) => b.data.length - a.data.length);
+  const sorted = [...files].sort((a, b) => b.size - a.size);
   const primary = sorted[0];
   const additional = sorted.slice(1).sort((a, b) => a.name.localeCompare(b.name));
 


### PR DESCRIPTION
Downloading Project Brutality (487 MB zip, 519 MB pk3 inside) crashed the app at "100%": validation read the whole file into the webview to check 2 magic bytes, extraction read it again and unzipSync'd it in memory, and the level-name scan repeated the whole-archive read on every launch. Measured: WebContent RSS ballooned 185 MB -> 3.35 GB; on machines with less headroom WebKit kills the process and the window goes blank, leaving a stale .zip.part (issue report).

New game_archives.rs commands stream disk-to-disk with constant memory: validate_game_file (4-byte magic check), extract_game_files, extract_zip_entry, list_zip_entries, read_zip_entry (size-capped raw-bytes IPC). The webview now only ever receives entry listings and small capped entries (MAPINFO, .txt sidecars, title screens).

- useDownload: validate + extract via Rust; new "Installing..." button state so the post-download extraction no longer looks stuck at 100%
- useLevelNames: scan archives from listings, read only small entries
- CustomModView/wadInspect: pk3 picks inspected via listing (no full read); zip picks stream-extract on submit; bare .wad reads capped with graceful fallback when too large to inspect
- read_file_for_inspection: raw-bytes response + cap (was Vec<u8> as JSON)

Verified live: re-downloaded Project Brutality; webview RSS stayed flat through install (Rust process steady at 154 MB), mod installed and launchable. cargo tests + vitest pass.

<img width="1312" height="912" alt="Screenshot 2026-06-10 at 22 54 17" src="https://github.com/user-attachments/assets/a52f2634-2673-4244-8900-ece08a3c36c7" />
