### PR TITLE
Improved GOG import

### DIFF
--- a/content/wads/id24res.json
+++ b/content/wads/id24res.json
@@ -1,0 +1,31 @@
+{
+  "slug": "id24res",
+  "title": "id24 shared resources",
+  "authors": [
+    {
+      "name": "id Software"
+    }
+  ],
+  "year": 2024,
+  "description": "Shared asset WAD of the id24 standard (new weapon and monster sprites, textures, sounds) introduced with Doom + Doom II (2024). Pure dependency: auto-loaded by content that requires it, such as Legacy of Rust.",
+  "iwad": "doom2",
+  "type": "resource-pack",
+  "sourcePort": "gzdoom",
+  "requires": [],
+  "downloads": [],
+  "thumbnail": "",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "official",
+    "id24"
+  ],
+  "difficulty": "unknown",
+  "notes": "Imported from an owned GOG release of Doom + Doom II (id24res.wad).",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/ID24"
+  ]
+}

--- a/content/wads/iddm1.json
+++ b/content/wads/iddm1.json
@@ -1,0 +1,41 @@
+{
+  "slug": "iddm1",
+  "title": "IDDM1",
+  "authors": [
+    {
+      "name": "id Software"
+    },
+    {
+      "name": "MachineGames"
+    }
+  ],
+  "year": 2024,
+  "description": "Official deathmatch map pack shipped with Doom + Doom II (2024). Arena-style multiplayer levels built on the id24 spec.",
+  "iwad": "doom2",
+  "type": "deathmatch",
+  "sourcePort": "gzdoom",
+  "requires": [
+    {
+      "slug": "id24res",
+      "name": "id24 shared resources",
+      "required": true
+    }
+  ],
+  "downloads": [],
+  "thumbnail": "",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "official",
+    "deathmatch",
+    "id24"
+  ],
+  "difficulty": "unknown",
+  "notes": "Imported from an owned GOG release of Doom + Doom II (iddm1.wad).",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/IDDM1"
+  ]
+}

--- a/content/wads/legacy-of-rust.json
+++ b/content/wads/legacy-of-rust.json
@@ -1,0 +1,44 @@
+{
+  "slug": "legacy-of-rust",
+  "title": "Legacy of Rust",
+  "authors": [
+    {
+      "name": "id Software"
+    },
+    {
+      "name": "MachineGames"
+    },
+    {
+      "name": "Nightdive Studios"
+    }
+  ],
+  "year": 2024,
+  "description": "The brand-new official episode duo shipped with Doom + Doom II (2024): sixteen levels built on the id24 spec, featuring new weapons like the Incinerator and Calamity Blade plus new enemy types. Requires a modern source port with id24 support (GZDoom 4.13+).",
+  "iwad": "doom2",
+  "type": "episode",
+  "sourcePort": "gzdoom",
+  "requires": [
+    {
+      "slug": "id24res",
+      "name": "id24 shared resources",
+      "required": true
+    }
+  ],
+  "downloads": [],
+  "thumbnail": "https://doomwiki.org/w/images/b/b9/Legacy_of_Rust_title.png",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "official",
+    "episode",
+    "id24"
+  ],
+  "difficulty": "medium",
+  "notes": "Imported from an owned GOG release of Doom + Doom II (id1.wad). [DoomWiki](https://doomwiki.org/wiki/Legacy_of_Rust)",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/Legacy_of_Rust"
+  ]
+}

--- a/content/wads/master-levels.json
+++ b/content/wads/master-levels.json
@@ -1,0 +1,31 @@
+{
+  "slug": "master-levels",
+  "title": "Master Levels for Doom II",
+  "authors": [
+    {
+      "name": "Various (published by id Software)"
+    }
+  ],
+  "year": 1995,
+  "description": "Twenty commissioned expert levels for Doom II by community legends including John Anderson (Dr. Sleep), Sverre Kvernmo and Tom Mustaine. The modern official release compiles them into a single WAD playable as one continuous episode.",
+  "iwad": "doom2",
+  "type": "megawad",
+  "sourcePort": "vanilla",
+  "requires": [],
+  "downloads": [],
+  "thumbnail": "https://doomwiki.org/w/images/2/21/Master_Levels_title.png",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "classic",
+    "official"
+  ],
+  "difficulty": "hard",
+  "notes": "Imported from an owned GOG release (masterlevels.wad, the compiled single-WAD edition). [DoomWiki](https://doomwiki.org/wiki/Master_Levels_for_Doom_II)",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/Master_Levels_for_Doom_II"
+  ]
+}

--- a/content/wads/no-rest-for-the-living.json
+++ b/content/wads/no-rest-for-the-living.json
@@ -1,0 +1,32 @@
+{
+  "slug": "no-rest-for-the-living",
+  "title": "No Rest for the Living",
+  "authors": [
+    {
+      "name": "Nerve Software"
+    }
+  ],
+  "year": 2010,
+  "description": "The official Doom II expansion episode by Nerve Software, originally made for the Xbox Live Arcade release. Nine tightly designed levels (plus a secret map) that ramp up classic Doom II combat with expert pacing. Included with modern official Doom II releases.",
+  "iwad": "doom2",
+  "type": "episode",
+  "sourcePort": "vanilla",
+  "requires": [],
+  "downloads": [],
+  "thumbnail": "https://doomwiki.org/w/images/5/59/NoRestForTheLiving_logo.png",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "classic",
+    "episode",
+    "official"
+  ],
+  "difficulty": "medium",
+  "notes": "Imported from an owned GOG release (nerve.wad). [DoomWiki](https://doomwiki.org/wiki/No_Rest_for_the_Living)",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/No_Rest_for_the_Living"
+  ]
+}

--- a/content/wads/sigil-2.json
+++ b/content/wads/sigil-2.json
@@ -1,0 +1,33 @@
+{
+  "slug": "sigil-2",
+  "title": "SIGIL II",
+  "authors": [
+    {
+      "name": "John Romero"
+    }
+  ],
+  "year": 2023,
+  "description": "John Romero's unofficial sixth episode for the original Doom, released for the game's 30th anniversary. Nine more single-player and deathmatch levels of vicious, lava-soaked combat, with a soundtrack by THORR.",
+  "iwad": "doom",
+  "type": "episode",
+  "sourcePort": "vanilla",
+  "requires": [],
+  "downloads": [],
+  "thumbnail": "https://doomwiki.org/w/images/a/a4/SIGIL_II_title.png",
+  "screenshots": [],
+  "youtubeVideos": [],
+  "awards": [],
+  "tags": [
+    "classic",
+    "episode",
+    "john-romero",
+    "official"
+  ],
+  "difficulty": "hard",
+  "notes": "Imported from an owned GOG release (sigil2.wad). Also available free at [romero.com](https://romero.com/sigil). [DoomWiki](https://doomwiki.org/wiki/SIGIL_II)",
+  "_schemaVersion": 1,
+  "_source": "manual",
+  "urls": [
+    "https://doomwiki.org/wiki/SIGIL_II"
+  ]
+}

--- a/src-tauri/src/game_archives.rs
+++ b/src-tauri/src/game_archives.rs
@@ -171,10 +171,8 @@ pub fn read_zip_entry(zip_path: &str, entry_path: &str) -> Result<Vec<u8>, Strin
     Ok(buf)
 }
 
-/// Stream a zip entry into a fresh temp directory and return its path.
-/// Used at pick time in the custom-mod importer so inspection and the
-/// eventual copy into the library work from a real, seekable file.
-pub fn extract_zip_entry_to_temp(zip_path: &str, entry_path: &str) -> Result<String, String> {
+/// Create a unique, empty temp directory owned by the launcher.
+pub fn create_temp_dir() -> Result<std::path::PathBuf, String> {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("System clock error: {}", e))?
@@ -185,6 +183,14 @@ pub fn extract_zip_entry_to_temp(zip_path: &str, entry_path: &str) -> Result<Str
         nanos
     ));
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {}: {}", dir.display(), e))?;
+    Ok(dir)
+}
+
+/// Stream a zip entry into a fresh temp directory and return its path.
+/// Used at pick time in the custom-mod importer so inspection and the
+/// eventual copy into the library work from a real, seekable file.
+pub fn extract_zip_entry_to_temp(zip_path: &str, entry_path: &str) -> Result<String, String> {
+    let dir = create_temp_dir()?;
     let dest = dir.join(basename(entry_path));
     let dest_str = dest.to_string_lossy().to_string();
     extract_zip_entry(zip_path, entry_path, &dest_str)?;

--- a/src-tauri/src/gog_import.rs
+++ b/src-tauri/src/gog_import.rs
@@ -1,0 +1,159 @@
+// Collection step of the GOG installer import. innoextract preserves the
+// installer's directory layout (`doom2/DOOM2.WAD`, `master/wads/…`,
+// `DOOM_Data/StreamingAssets/doom.wad`), which varies per installer — so
+// the frontend extracts into a temp directory and this walks it, moving
+// every wanted WAD flat into the destination under its canonical
+// lowercase name. The temp directory is removed afterwards.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use crate::game_archives::create_temp_dir;
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectedWad {
+    pub name: String,
+    pub size: u64,
+}
+
+pub fn make_temp_dir() -> Result<String, String> {
+    Ok(create_temp_dir()?.to_string_lossy().to_string())
+}
+
+fn walk_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|e| format!("Failed to read {}: {}", dir.display(), e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry in {}: {}", dir.display(), e))?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Move every file from `src_dir` (recursively) whose basename matches one
+/// of `wanted` (case-insensitive) into `dest_dir` under the canonical
+/// lowercase name, then delete `src_dir`. The first match per name wins —
+/// some installers carry duplicate WADs (e.g. a DOS copy alongside the
+/// main one).
+pub fn collect_known_wads(
+    src_dir: &str,
+    dest_dir: &str,
+    wanted: &[String],
+) -> Result<Vec<CollectedWad>, String> {
+    let wanted_lower: Vec<String> = wanted.iter().map(|w| w.to_lowercase()).collect();
+
+    let mut files = Vec::new();
+    walk_files(Path::new(src_dir), &mut files)?;
+    files.sort();
+
+    std::fs::create_dir_all(dest_dir)
+        .map_err(|e| format!("Failed to create {}: {}", dest_dir, e))?;
+
+    let mut collected: Vec<CollectedWad> = Vec::new();
+    for path in files {
+        let Some(name) = path.file_name().map(|n| n.to_string_lossy().to_lowercase()) else {
+            continue;
+        };
+        if !wanted_lower.contains(&name) {
+            continue;
+        }
+        if collected.iter().any(|c| c.name == name) {
+            continue;
+        }
+        let dest = Path::new(dest_dir).join(&name);
+        std::fs::copy(&path, &dest).map_err(|e| {
+            format!("Failed to copy {} -> {}: {}", path.display(), dest.display(), e)
+        })?;
+        let size = std::fs::metadata(&dest)
+            .map_err(|e| format!("Failed to stat {}: {}", dest.display(), e))?
+            .len();
+        collected.push(CollectedWad { name, size });
+    }
+
+    std::fs::remove_dir_all(src_dir)
+        .map_err(|e| format!("Failed to clean up {}: {}", src_dir, e))?;
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup(files: &[(&str, &[u8])]) -> (PathBuf, PathBuf) {
+        let src = create_temp_dir().unwrap();
+        let dest = create_temp_dir().unwrap();
+        for (rel, data) in files {
+            let path = src.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, data).unwrap();
+        }
+        (src, dest)
+    }
+
+    fn wanted(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn collects_wads_from_nested_dirs_with_canonical_names() {
+        let (src, dest) = setup(&[
+            ("doom2/DOOM2.WAD", b"PWAD2222"),
+            ("DOOM_Data/StreamingAssets/doom.wad", b"IWAD1111"),
+            ("master/wads/TEETH.WAD", b"PWADxxxx"),
+            ("tmp/error.png", b"png"),
+        ]);
+        let got = collect_known_wads(
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+            &wanted(&["doom.wad", "doom2.wad"]),
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            vec![
+                CollectedWad { name: "doom.wad".into(), size: 8 },
+                CollectedWad { name: "doom2.wad".into(), size: 8 },
+            ]
+        );
+        assert_eq!(std::fs::read(dest.join("doom2.wad")).unwrap(), b"PWAD2222");
+        assert!(!dest.join("TEETH.WAD").exists());
+        assert!(!src.exists(), "src temp dir should be removed");
+    }
+
+    #[test]
+    fn first_duplicate_wins() {
+        let (src, dest) = setup(&[
+            ("doom2/DOOM2.WAD", b"MAIN"),
+            ("dosdoom/base/doom2/DOOM2.WAD", b"DOS!"),
+        ]);
+        let got = collect_known_wads(
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+            &wanted(&["doom2.wad"]),
+        )
+        .unwrap();
+        assert_eq!(got.len(), 1);
+        // files are sorted, so "doom2/..." sorts before "dosdoom/..."
+        assert_eq!(std::fs::read(dest.join("doom2.wad")).unwrap(), b"MAIN");
+    }
+
+    #[test]
+    fn empty_when_nothing_matches() {
+        let (src, dest) = setup(&[("readme.txt", b"hi")]);
+        let got = collect_known_wads(
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+            &wanted(&["doom.wad"]),
+        )
+        .unwrap();
+        assert!(got.is_empty());
+        assert!(!src.exists());
+    }
+}

--- a/src-tauri/src/launcher_downloads.rs
+++ b/src-tauri/src/launcher_downloads.rs
@@ -17,6 +17,8 @@ pub struct DownloadInfo {
 	#[serde(rename = "downloadedAt")]
 	pub downloaded_at: String,
 	pub size: u64,
+	#[serde(rename = "externalPath", skip_serializing_if = "Option::is_none", default)]
+	pub external_path: Option<String>,
 }
 
 impl LauncherDownloads {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use std::thread;
 use tauri::Manager;
 
 pub mod game_archives;
+pub mod gog_import;
 pub mod launcher_downloads;
 
 #[tauri::command]
@@ -78,6 +79,23 @@ async fn read_zip_entry(
 #[tauri::command]
 async fn extract_zip_entry_to_temp(zip_path: String, entry_path: String) -> Result<String, String> {
     game_archives::extract_zip_entry_to_temp(&zip_path, &entry_path)
+}
+
+/// Create a unique temp directory (innoextract's --output-dir target).
+#[tauri::command]
+async fn make_temp_dir() -> Result<String, String> {
+    gog_import::make_temp_dir()
+}
+
+/// Move wanted WADs out of a GOG extraction temp dir into the iwads
+/// folder, flat and lowercase, regardless of the installer's layout.
+#[tauri::command]
+async fn collect_known_wads(
+    src_dir: String,
+    dest_dir: String,
+    wanted: Vec<String>,
+) -> Result<Vec<gog_import::CollectedWad>, String> {
+    gog_import::collect_known_wads(&src_dir, &dest_dir, &wanted)
 }
 
 /// Look for an idgames-style metadata sidecar next to a user-picked file.
@@ -523,7 +541,9 @@ pub fn run() {
             extract_game_files,
             extract_zip_entry_to_temp,
             list_zip_entries,
-            read_zip_entry
+            read_zip_entry,
+            make_temp_dir,
+            collect_known_wads
         ]);
 
     // MCP bridge for Claude Code debugging (dev mode only)

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,13 +60,17 @@ const { wads, loading, error } = useWads();
 const { detectIwads, availableIwads, launch, isRunning } = useGZDoom();
 const lib = useLibrary();
 
+const { loadState: loadDownloadState, downloadWithDeps, downloadWad, deleteWad, isDownloaded, getDownloadInfo, registerOwnedExpansions } = useDownload();
+
 const iwadEntries = computed<WadEntry[]>(() => availableIwads.value.map(synthIwadEntry));
+// Entries with no download URL (official expansions sourced from GOG
+// installers) only appear once their file is owned/imported.
+const obtainable = (w: WadEntry) => w.downloads.length > 0 || isDownloaded(w.slug);
 const playableEntries = computed<WadEntry[]>(() =>
-  [...iwadEntries.value, ...wads.value.filter(w => w.type !== "gameplay-mod" && w.type !== "resource-pack")]
+  [...iwadEntries.value, ...wads.value.filter(w => w.type !== "gameplay-mod" && w.type !== "resource-pack" && obtainable(w))]
 );
 const modEntries = computed<WadEntry[]>(() => wads.value.filter(w => w.type === "gameplay-mod"));
-const exploreEntries = computed<WadEntry[]>(() => wads.value.filter(w => w.type !== "resource-pack"));
-const { loadState: loadDownloadState, downloadWithDeps, downloadWad, deleteWad, isDownloaded, getDownloadInfo } = useDownload();
+const exploreEntries = computed<WadEntry[]>(() => wads.value.filter(w => w.type !== "resource-pack" && obtainable(w)));
 const { hasSlug: isCustomSlug, removeCustomWad, loadState: loadCustomWads } = useCustomWads();
 const { settings, isFirstRun, migratedIwads, initSettings, toggleActiveMod, pruneActiveMods } = useSettings();
 const { loadAllLevelNames } = useLevelNames();
@@ -109,6 +113,7 @@ onMounted(async () => {
   try {
     await initSettings();
     await loadDownloadState();
+    await registerOwnedExpansions();
     await loadCustomWads();
     await pruneActiveMods(s => wads.value.some(w => w.slug === s) && isDownloaded(s));
     await detectIwads();
@@ -211,11 +216,11 @@ async function handlePlay(wad: WadEntry, extraArgs?: string[]) {
     const callExtra = extraArgs ?? [];
     const combinedExtra = [...wadExtra, ...callExtra];
     if (wad.type === "iwad") {
-      await launch("", wad.iwad, modPaths, wad.slug, "HMP", combinedExtra);
+      await launch("", wad.iwad, [], modPaths, wad.slug, "HMP", combinedExtra);
       return;
     }
     const { wadPath, depPaths } = await downloadWithDeps(wad, wads.value);
-    await launch(wadPath, wad.iwad, [...depPaths, ...modPaths], wad.slug, "HMP", combinedExtra);
+    await launch(wadPath, wad.iwad, depPaths, modPaths, wad.slug, "HMP", combinedExtra);
   } catch (e) {
     console.error(`[Play] Error launching ${wad.slug}:`, e);
     errorMsg.value = getErrorMessage(e);

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -8,6 +8,7 @@ import { Check, X } from "lucide-vue-next";
 import { useSettings } from "../composables/useSettings";
 import { useGZDoom } from "../composables/useGZDoom";
 import { useLibrary } from "../composables/useLibrary";
+import { useDownload } from "../composables/useDownload";
 import { useWads } from "../composables/useWads";
 import type { Iwad } from "../lib/schema";
 import { shortenPath, getOs } from "../lib/platform";
@@ -16,6 +17,7 @@ const { settings, isFirstRun, migratedIwads, setGZDoomPath, setLibraryPath, chec
 const { availableIwads, detectIwads } = useGZDoom();
 const { wads } = useWads();
 const { iwadsDir } = useLibrary();
+const { registerOwnedExpansions } = useDownload();
 
 // IWADs required by games in the catalog
 const requiredIwads = computed<Iwad[]>(() => {
@@ -107,10 +109,12 @@ async function browseAndImportGOG() {
   try {
     const result = await importFromGOG(installerPath);
     await detectIwads();
+    const playable = await registerOwnedExpansions();
     if (result.extractedWads.length > 0) {
+      const expansionNote = playable.length > 0 ? ` — now playable: ${playable.join(", ")}` : "";
       gogImportResult.value = {
         success: true,
-        message: `Extracted: ${result.extractedWads.join(", ")}`,
+        message: `Extracted: ${result.extractedWads.join(", ")}${expansionNote}`,
       };
     } else {
       gogImportResult.value = {

--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -6,6 +6,7 @@ import type { WadEntry } from "../lib/schema";
 import { type LauncherDownloads } from "../lib/schema";
 import { useLevelNames } from "./useLevelNames";
 import { selectPrimaryGameFile, type GameFileInfo } from "../lib/zipExtract";
+import { GOG_EXPANSIONS } from "../lib/gogContent";
 import { useLibrary } from "./useLibrary";
 
 // Progress info for a download
@@ -30,7 +31,7 @@ async function validateDownload(path: string, filename: string): Promise<void> {
 
 export function useDownload() {
   const { loadLevelNames } = useLevelNames();
-  const { base, wadFile } = useLibrary();
+  const { base, wadFile, iwadFile } = useLibrary();
 
   /**
    * Extract game files (.wad/.pk3) from a ZIP archive into the library.
@@ -234,6 +235,36 @@ export function useDownload() {
   }
 
   /**
+   * Register official expansion WADs found in iwads/ (GOG import puts them
+   * there) as playable: each gets a synthetic download record whose
+   * externalPath points at the file, lighting up its catalog entry.
+   * Idempotent — existing records (including real downloads) are left alone.
+   * Returns the newly registered slugs.
+   */
+  async function registerOwnedExpansions(): Promise<string[]> {
+    const registered: string[] = [];
+    for (const expansion of GOG_EXPANSIONS) {
+      if (expansion.slug in downloads.value.downloads) continue;
+      const path = iwadFile(expansion.file);
+      if (!(await exists(path))) continue;
+      const fileStat = await stat(path);
+      downloads.value.downloads[expansion.slug] = {
+        filename: expansion.file,
+        wadFilename: expansion.file,
+        downloadedAt: new Date().toISOString(),
+        size: fileStat.size,
+        externalPath: path,
+      };
+      registered.push(expansion.slug);
+    }
+    if (registered.length > 0) {
+      await saveState();
+      console.log(`[registerOwnedExpansions] Registered: ${registered.join(", ")}`);
+    }
+    return registered;
+  }
+
+  /**
    * Write a synthetic LauncherDownloads record for a slug whose file is
    * already on disk (e.g. user-imported custom WAD). Mirrors what downloadWad
    * writes after a successful network download, so isDownloaded/getDownloadInfo
@@ -266,5 +297,6 @@ export function useDownload() {
     downloadWithDeps,
     deleteWad,
     registerSyntheticDownload,
+    registerOwnedExpansions,
   };
 }

--- a/src/composables/useGZDoom.ts
+++ b/src/composables/useGZDoom.ts
@@ -59,7 +59,10 @@ export function useGZDoom() {
   async function launch(
     wadPath: string,
     iwad: Iwad,
-    additionalFiles: string[] = [],
+    // Load order matters: dependencies (resource packs) come before the
+    // main WAD so it overrides them; mods come after so they override it.
+    depFiles: string[] = [],
+    modFiles: string[] = [],
     wadSlug?: string,
     skill: SkillLevel = "HMP",
     extraArgs: string[] = []
@@ -81,8 +84,9 @@ export function useGZDoom() {
 
     const args = [
       "-iwad", iwadPath,
+      ...depFiles.flatMap(f => ["-file", f]),
       ...(wadPath ? ["-file", wadPath] : []),
-      ...additionalFiles.flatMap(f => ["-file", f]),
+      ...modFiles.flatMap(f => ["-file", f]),
       ...(saveDir ? ["-savedir", saveDir] : []),
       ...extraArgs,
     ];

--- a/src/composables/useLevelNames.ts
+++ b/src/composables/useLevelNames.ts
@@ -54,7 +54,7 @@ export function useLevelNames() {
    * Reads launcher-downloads.json via IPC rather than importing useDownload
    * to avoid circular dependency (useDownload → useLevelNames → useDownload).
    */
-  async function getDownloadInfo(slug: string): Promise<{ filename: string } | null> {
+  async function getDownloadInfo(slug: string): Promise<{ filename: string; externalPath?: string } | null> {
     try {
       const state = await invoke<LauncherDownloads>("read_launcher_downloads", { libraryPath: base() });
       return state.downloads[slug] ?? null;
@@ -89,7 +89,10 @@ export function useLevelNames() {
         return null;
       }
 
-      const filePath = wadFile(downloadInfo.filename);
+      // externalPath is the authoritative absolute location when set
+      // (GOG-imported expansions in iwads/, user files referenced in place) —
+      // same resolution rule as the launch path in useDownload.
+      const filePath = downloadInfo.externalPath || wadFile(downloadInfo.filename);
       const filename = downloadInfo.filename.toLowerCase();
 
       let allLevels = new Map<string, string>();

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -2,8 +2,10 @@ import { ref } from "vue";
 import { appConfigDir, appDataDir, homeDir, join } from "@tauri-apps/api/path";
 import { exists, readTextFile, writeTextFile, mkdir, readDir, readFile, writeFile } from "@tauri-apps/plugin-fs";
 import { Command } from "@tauri-apps/plugin-shell";
+import { invoke } from "@tauri-apps/api/core";
 import { isNotFoundError } from "../lib/errors";
 import { getOs } from "../lib/platform";
+import { GOG_WANTED_WADS } from "../lib/gogContent";
 
 const OLD_APP_NAME = "gzdoom";
 
@@ -204,26 +206,16 @@ interface GOGExtractResult {
   errors: string[];
 }
 
-// Copyrighted WADs that must be extracted from owned installers
-// (SIGIL is free and can be downloaded separately, extras.wad is KEX-only bloat)
-const GOG_IWADS_TO_EXTRACT = [
-  "doom.wad",
-  "doom2.wad",
-  "plutonia.wad",
-  "tnt.wad",
-  "nerve.wad",
-  "masterlevels.wad",
-];
-
-// Extract IWADs from a GOG installer using innoextract
+// Extract game WADs from a GOG installer using innoextract. Installers
+// nest their WADs differently (doom2/DOOM2.WAD, DOOM_Data/StreamingAssets/
+// doom.wad, flat at the root, …), so extraction goes to a temp dir and
+// collect_known_wads flattens the wanted files into iwads/ regardless of
+// the layout inside the installer.
 async function extractFromGOG(
   installerPath: string,
   iwadsDir: string,
   innoextractCmd: string
 ): Promise<GOGExtractResult> {
-  // Ensure iwads directory exists
-  await mkdir(iwadsDir, { recursive: true });
-
   // List contents first to verify it's a valid Inno Setup installer
   const listResult = await Command.create(innoextractCmd, ["--list", installerPath]).execute();
   if (listResult.code !== 0) {
@@ -236,11 +228,11 @@ async function extractFromGOG(
     throw new Error("This installer doesn't appear to contain any WAD files");
   }
 
-  // Extract only copyrighted IWADs (skip extras.wad and freely available sigil)
-  const includeArgs = GOG_IWADS_TO_EXTRACT.flatMap(wad => ["--include", wad]);
+  const tempDir = await invoke<string>("make_temp_dir");
+  const includeArgs = GOG_WANTED_WADS.flatMap(wad => ["--include", wad]);
   const extractResult = await Command.create(innoextractCmd, [
     ...includeArgs,
-    "--output-dir", iwadsDir,
+    "--output-dir", tempDir,
     installerPath
   ]).execute();
 
@@ -249,20 +241,14 @@ async function extractFromGOG(
     errors.push(extractResult.stderr);
   }
 
-  // Check which WADs were actually extracted by checking if files exist
-  const extractedWads: string[] = [];
-  for (const wad of GOG_IWADS_TO_EXTRACT) {
-    try {
-      if (await exists(await join(iwadsDir, wad))) {
-        extractedWads.push(wad);
-      }
-    } catch {
-      // File doesn't exist
-    }
-  }
+  const collected = await invoke<{ name: string; size: number }[]>("collect_known_wads", {
+    srcDir: tempDir,
+    destDir: iwadsDir,
+    wanted: GOG_WANTED_WADS,
+  });
 
   return {
-    extractedWads,
+    extractedWads: collected.map(c => c.name),
     errors,
   };
 }

--- a/src/lib/gogContent.ts
+++ b/src/lib/gogContent.ts
@@ -1,0 +1,38 @@
+// What the GOG Doom installers can provide, and how it maps onto the
+// launcher's content model.
+//
+// Base IWADs land in iwads/ and surface as synthetic base-game cards.
+// Expansions (official add-on PWADs) also land in iwads/ — they are owned
+// game data, not downloads — and get a synthetic download record with
+// externalPath pointing there, which lights up their catalog entry
+// (content/wads/<slug>.json) as playable.
+
+/** -iwad targets recognized by the engine. */
+export const GOG_BASE_IWADS = [
+  "doom.wad",
+  "doom2.wad",
+  "plutonia.wad",
+  "tnt.wad",
+  "heretic.wad",
+  "hexen.wad",
+];
+
+export interface GogExpansion {
+  /** Canonical lowercase filename inside iwads/. */
+  file: string;
+  /** Slug of the catalog entry this file makes playable. */
+  slug: string;
+}
+
+export const GOG_EXPANSIONS: GogExpansion[] = [
+  { file: "nerve.wad", slug: "no-rest-for-the-living" },
+  { file: "masterlevels.wad", slug: "master-levels" },
+  { file: "sigil.wad", slug: "sigil" },
+  { file: "sigil2.wad", slug: "sigil-2" },
+  { file: "id1.wad", slug: "legacy-of-rust" },
+  { file: "id24res.wad", slug: "id24res" },
+  { file: "iddm1.wad", slug: "iddm1" },
+];
+
+/** Everything worth pulling out of a GOG installer. */
+export const GOG_WANTED_WADS = [...GOG_BASE_IWADS, ...GOG_EXPANSIONS.map(e => e.file)];

--- a/src/lib/schema.test.ts
+++ b/src/lib/schema.test.ts
@@ -6,6 +6,7 @@ import {
   YouTubeVideoSchema,
   safeValidateWadEntry,
 } from "./schema";
+import { GOG_EXPANSIONS } from "./gogContent";
 
 // Check if a YouTube video actually exists via oEmbed API
 async function youtubeVideoExists(videoId: string): Promise<boolean> {
@@ -270,9 +271,14 @@ describe("WAD JSON files content checks", () => {
         expect(data.authors[0].name.length).toBeGreaterThan(0);
       });
 
-      it("should have at least one download source", () => {
-        expect(data.downloads.length).toBeGreaterThan(0);
-        expect(data.downloads[0].url).toMatch(/^https?:\/\//);
+      it("should have at least one download source (unless obtainable via GOG import)", () => {
+        const gogSourced = GOG_EXPANSIONS.some(e => e.slug === data.slug);
+        if (!gogSourced) {
+          expect(data.downloads.length).toBeGreaterThan(0);
+        }
+        for (const download of data.downloads) {
+          expect(download.url).toMatch(/^https?:\/\//);
+        }
       });
 
       it("should have valid year", () => {


### PR DESCRIPTION
GOG import: find WADs in any installer layout; surface expansions as playable

GOG installers nest their WADs differently — doom2/DOOM2.WAD (Doom II + Master Levels), Plutonia/PLUTONIA.WAD (Final Doom), DOOM_Data/ StreamingAssets/doom.wad (Enhanced), flat at the root (Doom + Doom II) — and the old import extracted with --output-dir straight into iwads/ and then checked flat paths, so anything nested landed unseen in a subdirectory (issue: Doom II installer "extracts doom.wad but not doom2.wad"). Import now extracts into a temp dir and a Rust command walks it and moves every wanted WAD flat into iwads/ under its canonical lowercase name, deduping the DOS copies some installers carry.

The installers also ship official expansions the launcher ignored. These now become playable: nerve.wad, masterlevels.wad, sigil.wad, sigil2.wad, id1.wad (+ id24res.wad as its hidden resource-pack dependency) and iddm1.wad get catalog entries; on startup and after each import, any of them found in iwads/ is auto-registered as a synthetic download whose externalPath points there. Entries without a download URL stay hidden until their file is owned.

Fixes found along the way:
- launcher_downloads.rs DownloadInfo had no externalPath field, so serde silently dropped it on every save — breaking by-reference imports
- level-name scanning ignored externalPath and looked in the library root
- launch order: dependency files now load before the main WAD (it overrides them), mods after it

Verified live against all five installer layouts; Legacy of Rust launches in UZDoom 4.14.3 with id24res auto-loaded (MAP01 "Scar Gate") and level names extract for all six expansions.

Should word with these:

<img width="687" height="468" alt="Screenshot 2026-06-11 at 00 41 29" src="https://github.com/user-attachments/assets/ebd69eac-9f26-4b97-85a1-3c78d022e8eb" />

You can play then:

<img width="1467" height="1116" alt="Screenshot 2026-06-11 at 00 41 52" src="https://github.com/user-attachments/assets/87badd12-835b-426e-9a45-7435cf22030f" />
