### PR TITLE
Tauri folders

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -150,6 +150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3342,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-mcp-bridge",
+ "tauri-plugin-persisted-scope",
  "tauri-plugin-shell",
  "tauri-plugin-upload",
  "windows",
@@ -4217,6 +4227,22 @@ dependencies = [
  "webview2-com",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "tauri-plugin-persisted-scope"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e4639faf38e4527a4549cbc68b788c0d29b03b65e65f1590f5ec582df5d028"
+dependencies = [
+ "aho-corasick",
+ "bincode",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-persisted-scope = "2"
 tauri-plugin-upload = "2"
 # MCP bridge for Claude Code debugging (hypothesi/tauri-mcp-server)
 tauri-plugin-mcp-bridge = "0.8"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,13 +13,7 @@
         "fs:default",
         "fs:allow-app-write-recursive",
         "fs:allow-app-meta-recursive",
-        "upload:default",
-        {
-          "identifier": "upload:allow-download",
-          "allow": [
-            { "path": "$APPDATA/com.doomwads.launcher/**" }
-          ]
-        }
+        "upload:default"
       ]
     },
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -518,6 +518,9 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        // Folders granted via the file dialog stay in the fs scope across
+        // restarts; without this a custom Data Folder breaks on next launch.
+        .plugin(tauri_plugin_persisted_scope::init())
         .plugin(tauri_plugin_upload::init())
         .setup(|app| {
             let app_data_dir = app.path().app_data_dir()?;

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -4,6 +4,7 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import { invoke } from "@tauri-apps/api/core";
 import { mkdir } from "@tauri-apps/plugin-fs";
+import { join } from "@tauri-apps/api/path";
 import { Check, X } from "lucide-vue-next";
 import { useSettings } from "../composables/useSettings";
 import { useGZDoom } from "../composables/useGZDoom";
@@ -171,7 +172,16 @@ async function browseLibrary() {
   });
   if (selected) {
     const path = typeof selected === "string" ? selected : selected[0];
+    // The folder must be usable before we store it: creating iwads/ here
+    // rejects unwritable picks (e.g. system /Library) at dialog time.
+    try {
+      await mkdir(await join(path, "iwads"), { recursive: true });
+    } catch (e) {
+      errorMsg.value = `Cannot use "${path}" as Data Folder: ${e instanceof Error ? e.message : String(e)}`;
+      return;
+    }
     await setLibraryPath(path);
+    errorMsg.value = "";
     await detectIwads();
   }
 }


### PR DESCRIPTION
* Fixes "forbidden path" after restart (#40-style reports): custom Data Folders picked via the file dialog lost their
  fs-scope grant on relaunch — tauri-plugin-persisted-scope now makes those grants durable.
* Browse also validates the picked folder at dialog time by creating iwads/ in it, so unwritable picks (e.g. system
  /Library) are rejected immediately with the real error.
* Cleanup: removed the dead upload:allow-download scope still referencing the pre-rename com.doomwads.launcher identifier
  (upload:default already covers downloads).